### PR TITLE
Apply eslint and other formatting from SWB v5.2.7 to minimise diffs

### DIFF
--- a/src/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/appstream/appstream-sc-service.js
+++ b/src/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/appstream/appstream-sc-service.js
@@ -55,10 +55,7 @@ class AppStreamScService extends Service {
       .promise();
 
     // Write audit event
-    await this.audit(requestContext, {
-      action: 'share-appstream-image-with-account',
-      body: { accountId },
-    });
+    await this.audit(requestContext, { action: 'share-appstream-image-with-account', body: { accountId } });
 
     return result;
   }
@@ -71,9 +68,7 @@ class AppStreamScService extends Service {
     ]);
 
     // Find stack
-    const { awsAccountId } = await indexesService.mustFind(requestContext, {
-      id: indexId,
-    });
+    const { awsAccountId } = await indexesService.mustFind(requestContext, { id: indexId });
     const {
       appStreamStackName: stackName,
       accountId,
@@ -129,9 +124,7 @@ class AppStreamScService extends Service {
       { clientName: 'AppStream', options: { signatureVersion: 'v4' } },
     );
 
-    const environment = await environmentScService.mustFind(requestContext, {
-      id: environmentId,
-    });
+    const environment = await environmentScService.mustFind(requestContext, { id: environmentId });
 
     const { stackName, fleetName } = await this.getStackAndFleet(requestContext, {
       environmentId,
@@ -155,10 +148,7 @@ class AppStreamScService extends Service {
     }
 
     // Write audit event
-    await this.audit(requestContext, {
-      action: 'appstream-firefox-app-url-requested',
-      body: { environmentId },
-    });
+    await this.audit(requestContext, { action: 'appstream-firefox-app-url-requested', body: { environmentId } });
 
     return result.StreamingURL;
   }
@@ -168,9 +158,7 @@ class AppStreamScService extends Service {
       'environmentScService',
       'environmentScKeypairService',
     ]);
-    const environment = await environmentScService.mustFind(requestContext, {
-      id: environmentId,
-    });
+    const environment = await environmentScService.mustFind(requestContext, { id: environmentId });
 
     const connectionScheme = environment.outputs.filter(output =>
       output.OutputValue === 'customrdp' || output.OutputValue === 'rdp' ? output.OutputValue : undefined,
@@ -198,10 +186,7 @@ class AppStreamScService extends Service {
     const privateIp = _.get(networkInterfaces[0], 'PrivateIpAddress');
 
     const userId = this.generateUserId(requestContext, environment);
-    this.log.info({
-      msg: `Creating AppStream URL`,
-      appStreamSessionUid: userId,
-    });
+    this.log.info({ msg: `Creating AppStream URL`, appStreamSessionUid: userId });
 
     let sessionContext;
     if (connectionScheme && connectionScheme[0].OutputValue === 'rdp') {
@@ -246,10 +231,7 @@ class AppStreamScService extends Service {
     }
 
     // Write audit event
-    await this.audit(requestContext, {
-      action: 'appstream-remote-desktop-app-url-requested',
-      body: { environmentId },
-    });
+    await this.audit(requestContext, { action: 'appstream-remote-desktop-app-url-requested', body: { environmentId } });
 
     return result.StreamingURL;
   }

--- a/src/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/env-sc-connection-url-plugin.js
+++ b/src/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/env-sc-connection-url-plugin.js
@@ -27,7 +27,7 @@ async function createConnectionUrl({ envId, connection }, { requestContext, cont
   const isRdp = connection.scheme === 'rdp' || connection.scheme === 'customrdp';
   const appStreamScService = await container.find('appStreamScService');
   const environmentScConnectionService = await container.find('environmentScConnectionService');
-  const environmentScService = await container.find("environmentScService");
+  const environmentScService = await container.find('environmentScService');
   const settings = await container.find('settings');
   const isAppStreamEnabled = settings.getBoolean(settingKeys.isAppStreamEnabled);
 
@@ -61,14 +61,12 @@ async function createConnectionUrl({ envId, connection }, { requestContext, cont
     const ec2 = await environmentScService.getClientSdkWithEnvMgmtRole(
       requestContext,
       { id: envId },
-      { clientName: "EC2", options: { apiVersion: "2016-11-15" } }
+      { clientName: 'EC2', options: { apiVersion: '2016-11-15' } },
     );
-    const data = await ec2
-      .describeInstances({ InstanceIds: [connection.instanceId] })
-      .promise();
-    const instanceInfo = _.get(data, "Reservations[0].Instances[0]");
-    const networkInterfaces = _.get(instanceInfo, "NetworkInterfaces") || [];
-    const privateIp = _.get(networkInterfaces[0], "PrivateIpAddress");
+    const data = await ec2.describeInstances({ InstanceIds: [connection.instanceId] }).promise();
+    const instanceInfo = _.get(data, 'Reservations[0].Instances[0]');
+    const networkInterfaces = _.get(instanceInfo, 'NetworkInterfaces') || [];
+    const privateIp = _.get(networkInterfaces[0], 'PrivateIpAddress');
     appStreamUrl = await appStreamScService.getStreamingUrl(requestContext, {
       environmentId: envId,
       applicationId: 'terminal',

--- a/src/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentHttpConnections.js
+++ b/src/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentHttpConnections.js
@@ -222,9 +222,9 @@ class ScEnvironmentHttpConnections extends React.Component {
               <Table.Row key={`${item.id}_destination`} className="fadeIn animated">
                 <Table.Cell colSpan="3" className="p3">
                   Click here to copy the destination URL:
-                  <CopyToClipboard text={destinationUrl.replace('.sagemaker.aws','.sagemaker.aws\/lab')} />
+                  <CopyToClipboard text={destinationUrl.replace('.sagemaker.aws', '.sagemaker.aws/lab')} />
                   <span data-testid="destination-url" style={destinationUrlStyle}>
-                    {destinationUrl.replace('.sagemaker.aws','.sagemaker.aws\/lab')}
+                    {destinationUrl.replace('.sagemaker.aws', '.sagemaker.aws/lab')}
                   </span>
                   <Button
                     floated="right"

--- a/src/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentRdpConnectionRow.js
+++ b/src/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentRdpConnectionRow.js
@@ -75,20 +75,8 @@ class ScEnvironmentRdpConnectionRow extends React.Component {
 
     const result = [];
     _.forEach(entries, item => {
-      if (item.publicDnsName)
-        result.push({
-          value: item.publicDnsName,
-          type: 'dns',
-          scope: 'public',
-          info: 'Public',
-        });
-      if (item.privateIp)
-        result.push({
-          value: item.privateIp,
-          type: 'ip',
-          scope: 'private',
-          info: 'Private',
-        });
+      if (item.publicDnsName) result.push({ value: item.publicDnsName, type: 'dns', scope: 'public', info: 'Public' });
+      if (item.privateIp) result.push({ value: item.privateIp, type: 'ip', scope: 'private', info: 'Private' });
     });
 
     return result;

--- a/src/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentRdpConnectionRow.js
+++ b/src/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentRdpConnectionRow.js
@@ -1,16 +1,16 @@
-import _ from "lodash";
-import React from "react";
-import { decorate, computed, action, runInAction, observable } from "mobx";
-import { observer, inject } from "mobx-react";
-import { withRouter } from "react-router-dom";
-import { Button, Table, List, Label } from "semantic-ui-react";
+import _ from 'lodash';
+import React from 'react';
+import { decorate, computed, action, runInAction, observable } from 'mobx';
+import { observer, inject } from 'mobx-react';
+import { withRouter } from 'react-router-dom';
+import { Button, Table, List, Label } from 'semantic-ui-react';
 
-import { displayError } from "@amzn/base-ui/dist/helpers/notification";
+import { displayError } from '@amzn/base-ui/dist/helpers/notification';
 
-import CopyToClipboard from "../../helpers/CopyToClipboard";
+import CopyToClipboard from '../../helpers/CopyToClipboard';
 
 const openWindow = (url, windowFeatures) => {
-  return window.open(url, "_blank", windowFeatures);
+  return window.open(url, '_blank', windowFeatures);
 };
 
 // expected props
@@ -35,7 +35,7 @@ class ScEnvironmentRdpConnectionRow extends React.Component {
   }
 
   get isAppStreamEnabled() {
-    return process.env.REACT_APP_IS_APP_STREAM_ENABLED === "true";
+    return process.env.REACT_APP_IS_APP_STREAM_ENABLED === 'true';
   }
 
   get environment() {
@@ -53,9 +53,7 @@ class ScEnvironmentRdpConnectionRow extends React.Component {
   // Returns only the connections that scheme = 'rdp'
   // [ {id, name: <string>(optional), instanceId: <string>, scheme: 'rdp'}, ... ]
   get connections() {
-    const connections = this.environment.getConnections(
-      (item) => item.scheme === "rdp"
-    );
+    const connections = this.environment.getConnections(item => item.scheme === 'rdp');
 
     return connections;
   }
@@ -64,7 +62,7 @@ class ScEnvironmentRdpConnectionRow extends React.Component {
     const id = this.connectionId;
     const connections = this.connections;
 
-    return _.find(connections, ["id", id]) || {};
+    return _.find(connections, ['id', id]) || {};
   }
 
   get connectionId() {
@@ -72,31 +70,31 @@ class ScEnvironmentRdpConnectionRow extends React.Component {
   }
 
   get networkInterfaces() {
-    const entries = _.get(this.windowsRdpInfo, "networkInterfaces");
+    const entries = _.get(this.windowsRdpInfo, 'networkInterfaces');
     if (_.isEmpty(entries)) return [];
 
     const result = [];
-    _.forEach(entries, (item) => {
+    _.forEach(entries, item => {
       if (item.publicDnsName)
         result.push({
           value: item.publicDnsName,
-          type: "dns",
-          scope: "public",
-          info: "Public",
+          type: 'dns',
+          scope: 'public',
+          info: 'Public',
         });
       if (item.privateIp)
         result.push({
           value: item.privateIp,
-          type: "ip",
-          scope: "private",
-          info: "Private",
+          type: 'ip',
+          scope: 'private',
+          info: 'Private',
         });
     });
 
     return result;
   }
 
-  handleConnect = (id) =>
+  handleConnect = id =>
     action(async () => {
       try {
         runInAction(() => {
@@ -106,10 +104,10 @@ class ScEnvironmentRdpConnectionRow extends React.Component {
         const urlObj = await store.createConnectionUrl(id);
         const appStreamUrl = urlObj.url;
         if (appStreamUrl) {
-          const newTab = openWindow("about:blank");
+          const newTab = openWindow('about:blank');
           newTab.location = appStreamUrl;
         } else {
-          throw Error("AppStream URL was not returned by the API");
+          throw Error('AppStream URL was not returned by the API');
         }
         runInAction(() => {
           this.processingGetConnection = false;
@@ -119,7 +117,7 @@ class ScEnvironmentRdpConnectionRow extends React.Component {
         displayError(error);
       } finally {
         runInAction(() => {
-          this.processingId = "";
+          this.processingId = '';
         });
       }
     });
@@ -171,7 +169,7 @@ class ScEnvironmentRdpConnectionRow extends React.Component {
             Get Password
           </Button>
 
-          <div className="mt1">{item.name || "Connect"}</div>
+          <div className="mt1">{item.name || 'Connect'}</div>
         </Table.Cell>
       </Table.Row>,
     ];
@@ -188,7 +186,7 @@ class ScEnvironmentRdpConnectionRow extends React.Component {
     const windowsRdpInfo = this.windowsRdpInfo;
     const interfaces = this.networkInterfaces;
     const network = interfaces[0];
-    const username = "Administrator";
+    const username = 'Administrator';
     const password = windowsRdpInfo.password;
     const showPassword = this.showPassword;
     const connectionId = this.connectionId;
@@ -198,19 +196,14 @@ class ScEnvironmentRdpConnectionRow extends React.Component {
       <>
         <Table.Row key={`${item.id}__2`}>
           <Table.Cell className="p3">
-            <b>
-              Your workspace can be accessed via an RDP client by using
-              the credentials defined below.
-            </b>
+            <b>Your workspace can be accessed via an RDP client by using the credentials defined below.</b>
             <List bulleted>
               {!this.isAppStreamEnabled && (
                 <List.Item>
-                  The IP Address or DNS of the instance.{" "}
-                  {moreThanOne
-                    ? "Ask your administrator if you are not sure which one to use:"
-                    : ""}
+                  The IP Address or DNS of the instance.{' '}
+                  {moreThanOne ? 'Ask your administrator if you are not sure which one to use:' : ''}
                   <List>
-                    {_.map(interfaces, (network) => (
+                    {_.map(interfaces, network => (
                       <List.Item key={network.value} className="flex">
                         {this.renderHostLabel(network)}
                         <CopyToClipboard text={network.value} />
@@ -220,7 +213,7 @@ class ScEnvironmentRdpConnectionRow extends React.Component {
                 </List.Item>
               )}
               <List.Item>
-                The Private IP Address to be used:{" "}
+                The Private IP Address to be used:{' '}
                 <List bulleted>
                   <List.Item key={network.value} className="flex">
                     {this.renderHostLabel(network)}
@@ -237,13 +230,8 @@ class ScEnvironmentRdpConnectionRow extends React.Component {
                   </List.Item>
                   <List.Item className="flex">
                     {this.renderPasswordLabel(password)}
-                    <Button
-                      className="ml2"
-                      basic
-                      size="mini"
-                      onClick={this.toggleShowPassword}
-                    >
-                      {showPassword ? "Hide" : "Show"}
+                    <Button className="ml2" basic size="mini" onClick={this.toggleShowPassword}>
+                      {showPassword ? 'Hide' : 'Show'}
                     </Button>
                     <CopyToClipboard text={password} />
                   </List.Item>
@@ -251,22 +239,17 @@ class ScEnvironmentRdpConnectionRow extends React.Component {
               </List.Item>
             </List>
             <div className="mt3">
-              Additional information about connecting via RDP can be found in
-              the documentation below:
+              Additional information about connecting via RDP can be found in the documentation below:
             </div>
             <List bulleted>
-              <List.Item
-                href="https://remmina.org/remmina-rdp/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
+              <List.Item href="https://remmina.org/remmina-rdp/" target="_blank" rel="noopener noreferrer">
                 Connect to workspace
               </List.Item>
             </List>
             {this.isAppStreamEnabled && (
               <div className="mt3">
-                In your browser, please allow popups for this domain so we can
-                open the AppStream page in a new tab for you
+                In your browser, please allow popups for this domain so we can open the AppStream page in a new tab for
+                you
               </div>
             )}
           </Table.Cell>
@@ -298,9 +281,7 @@ class ScEnvironmentRdpConnectionRow extends React.Component {
     return (
       <Label>
         Password
-        <Label.Detail>
-          {showPassword ? password : "****************"}
-        </Label.Detail>
+        <Label.Detail>{showPassword ? password : '****************'}</Label.Detail>
       </Label>
     );
   }
@@ -343,6 +324,4 @@ decorate(ScEnvironmentRdpConnectionRow, {
   toggleShowPassword: action,
 });
 
-export default inject("scEnvironmentsStore")(
-  withRouter(observer(ScEnvironmentRdpConnectionRow))
-);
+export default inject('scEnvironmentsStore')(withRouter(observer(ScEnvironmentRdpConnectionRow)));

--- a/src/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentSshConnections.js
+++ b/src/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentSshConnections.js
@@ -108,9 +108,7 @@ class ScEnvironmentSshConnections extends React.Component {
               <List.Item>Paste your SSH key&apos;s contents into the terminal window launched in AppStream</List.Item>
             </List>
           </List.Item>
-          <List.Item>
-            You should be automatically logged into an SSH session.
-          </List.Item>
+          <List.Item>You should be automatically logged into an SSH session.</List.Item>
           <List.Item>
             If you get a Permissions Denied error, click &quot;Use this SSH key&quot; and try launcing terminal
           </List.Item>

--- a/src/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/src/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -48,12 +48,12 @@ Parameters:
   LaunchConstraintRolePrefix:
     Description: Role name prefix to use when creating a launch constraint role in the on-boarded account
     Type: String
-    Default: "*"
+    Default: '*'
 
   LaunchConstraintPolicyPrefix:
     Description: Customer managed policy name prefix to use when creating a launch constraint role in the on-boarded account
     Type: String
-    Default: "*"
+    Default: '*'
 
   #------------AppStream Parameters Below-------
   # Range from 10.0.32.0 to 10.0.63.255
@@ -110,7 +110,7 @@ Parameters:
   DomainName:
     Description: Optional custom Domain name to be created in Route53
     Type: String
-    Default: ""
+    Default: ''
 
   EnableAmiSharing:
     Type: String
@@ -121,7 +121,7 @@ Parameters:
   DevopsAccountId:
     Type: String
     Description: The account id of the central AWS account where the appstream image is created.
-    Default: ""
+    Default: ''
 
   S3PrefixList:
     Description: Specific to each region, subnet prefix list to S3. ("aws ec2 describe-prefix-lists --region=<REGION> --filter Name=prefix-list-name,Values=com.amazonaws.\*.s3")
@@ -165,18 +165,30 @@ Conditions:
     - !Ref EnableAppStream
     - true
   isNotAppStream: !Not [Condition: isAppStream]
-  isElasticAppStream: !And [!Equals [!Ref "EnableAppStream", true], !Equals [!Ref "AppStreamFleetType", ELASTIC]]
+  isElasticAppStream:
+    !And [
+      !Equals [!Ref 'EnableAppStream', true],
+      !Equals [!Ref 'AppStreamFleetType', ELASTIC],
+    ]
   isNotElasticAppStream: !Not [Condition: isElasticAppStream]
   isAppStreamAndCustomDomain: !And
-    - !Not [!Equals [!Ref "DomainName", ""]]
+    - !Not [!Equals [!Ref 'DomainName', '']]
     - !Condition isAppStream
   enableFlowLogs: !Equals [!Ref EnableFlowLogs, true]
   enableFlowLogsNonAppStream:
     !And [Condition: isNotAppStream, Condition: enableFlowLogs]
   enableFlowLogsWithAppStream:
     !And [Condition: isAppStream, Condition: enableFlowLogs]
-  amiSharingEnabled: !And [!Equals [!Ref "EnableAmiSharing", true], Condition: isNotElasticAppStream]
-  notAmiSharingEnabled: !And [!Not [!Equals [!Ref "EnableAmiSharing", true]], Condition: isNotElasticAppStream]
+  amiSharingEnabled:
+    !And [
+      !Equals [!Ref 'EnableAmiSharing', true],
+      Condition: isNotElasticAppStream,
+    ]
+  notAmiSharingEnabled:
+    !And [
+      !Not [!Equals [!Ref 'EnableAmiSharing', true]],
+      Condition: isNotElasticAppStream,
+    ]
 
 Resources:
   Route53HostedZone:
@@ -186,7 +198,7 @@ Resources:
       Name: !Ref DomainName
       VPCs:
         - VPCId: !Ref VPC
-          VPCRegion: !Ref "AWS::Region"
+          VPCRegion: !Ref 'AWS::Region'
 
   # A role used for launching environments using AWS Service Catalog
   # This is the role that code (ApiHandlerLambda and WorkflowLoopRunnerLambda) in central account
@@ -194,21 +206,21 @@ Resources:
   # for launching environments.
   # Equivalent role for central account is created by 'main/solution/backend/config/infra/cloudformation.yml'
   CrossAccountRoleEnvMgmt:
-    Type: "AWS::IAM::Role"
+    Type: 'AWS::IAM::Role'
     Properties:
-      RoleName: !Join ["-", [Ref: Namespace, "xacc-env-mgmt"]]
-      Path: "/"
+      RoleName: !Join ['-', [Ref: Namespace, 'xacc-env-mgmt']]
+      Path: '/'
       AssumeRolePolicyDocument:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement:
-          - Effect: "Allow"
+          - Effect: 'Allow'
             Principal:
               AWS:
-                - !Join [":", ["arn:aws:iam:", Ref: CentralAccountId, "root"]]
+                - !Join [':', ['arn:aws:iam:', Ref: CentralAccountId, 'root']]
                 - !Ref ApiHandlerArn
                 - !Ref WorkflowRoleArn
             Action:
-              - "sts:AssumeRole"
+              - 'sts:AssumeRole'
             Condition:
               StringEquals:
                 sts:ExternalId: !Ref ExternalId
@@ -230,26 +242,26 @@ Resources:
                 - ec2:RevokeSecurityGroup*
                 - ec2:AuthorizeSecurityGroup*
                 - ec2-instance-connect:SendSSHPublicKey
-              Resource: "*"
+              Resource: '*'
         - PolicyName: cfn-access
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:
                   - cloudformation:GetTemplate
-                Resource: "arn:aws:cloudformation:*:*:stack/SC-*/*"
+                Resource: 'arn:aws:cloudformation:*:*:stack/SC-*/*'
         - PolicyName: appstream-access
           PolicyDocument:
-            Version: "2012-10-17"
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
                 Action:
                   - appstream:ListAssociatedFleets
                   - appStream:CreateStreamingURL
                 Resource:
-                  - !Sub "arn:${AWS::Partition}:appstream:${AWS::Region}:${AWS::AccountId}:stack/*"
-                  - !Sub "arn:${AWS::Partition}:appstream:${AWS::Region}:${AWS::AccountId}:fleet/*"
+                  - !Sub 'arn:${AWS::Partition}:appstream:${AWS::Region}:${AWS::AccountId}:stack/*'
+                  - !Sub 'arn:${AWS::Partition}:appstream:${AWS::Region}:${AWS::AccountId}:fleet/*'
         - PolicyName: ssm-access
           PolicyDocument:
             Statement:
@@ -260,7 +272,7 @@ Resources:
                 - ssm:GetParameters
                 - ssm:DeleteParameter
               Resource:
-                - !Sub "arn:aws:ssm:*:${AWS::AccountId}:parameter/*/sc-environments/*"
+                - !Sub 'arn:aws:ssm:*:${AWS::AccountId}:parameter/*/sc-environments/*'
         - PolicyName: s3-access
           PolicyDocument:
             Statement:
@@ -268,7 +280,7 @@ Resources:
               Action:
                 - s3:GetObject
               Resource:
-                - "arn:aws:s3:::cf-templates-*/*"
+                - 'arn:aws:s3:::cf-templates-*/*'
         - PolicyName: s3-upload-access
           PolicyDocument:
             Statement:
@@ -276,7 +288,7 @@ Resources:
               Action:
                 - s3:PutObject*
               Resource:
-                - !Sub "arn:aws:s3:::${Namespace}*/*"
+                - !Sub 'arn:aws:s3:::${Namespace}*/*'
         - PolicyName: sts-assume-create-presign
           PolicyDocument:
             Statement:
@@ -284,7 +296,7 @@ Resources:
               Action:
                 - sts:AssumeRole
               Resource:
-                - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*presigned-url-sagemaker-notebook-role"
+                - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*presigned-url-sagemaker-notebook-role'
         - PolicyName: sagemaker-access
           PolicyDocument:
             Statement:
@@ -292,7 +304,7 @@ Resources:
               Action:
                 - sagemaker:CreatePresignedNotebookInstanceUrl
                 - sagemaker:ListNotebookInstances
-              Resource: "*"
+              Resource: '*'
         - PolicyName: iam-role-access
           PolicyDocument:
             Statement:
@@ -310,8 +322,8 @@ Resources:
                   - iam:AttachRolePolicy
                   - iam:DetachRolePolicy
                 Resource:
-                  - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${LaunchConstraintRolePrefix}LaunchConstraint"
-                  - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*presigned-url-sagemaker-notebook-role"
+                  - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${LaunchConstraintRolePrefix}LaunchConstraint'
+                  - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*presigned-url-sagemaker-notebook-role'
         - PolicyName: cloudwatch-access-policy
           PolicyDocument:
             Statement:
@@ -321,8 +333,8 @@ Resources:
                 - logs:CreateLogStream
                 - logs:PutLogEvents
               Resource:
-                - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${Namespace}-*:*"
-                - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${Namespace}-*:log-stream:*"
+                - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${Namespace}-*:*'
+                - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${Namespace}-*:log-stream:*'
         - !If
           - isAppStreamAndCustomDomain
           - PolicyName: route53-access
@@ -332,8 +344,8 @@ Resources:
                   Action:
                     - route53:ChangeResourceRecordSets
                   Resource:
-                    - !Sub "arn:aws:route53:::hostedzone/${Route53HostedZone}"
-          - !Ref "AWS::NoValue"
+                    - !Sub 'arn:aws:route53:::hostedzone/${Route53HostedZone}'
+          - !Ref 'AWS::NoValue'
       PermissionsBoundary: !Ref CrossAccountEnvMgmtPermissionsBoundary
 
   CrossAccountEnvMgmtPermissionsBoundary:
@@ -341,13 +353,13 @@ Resources:
     Properties:
       Description: Permission boundary for cross account EnvMgmt role
       PolicyDocument:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:
               - sts:AssumeRole
             Resource:
-              - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*presigned-url-sagemaker-notebook-role"
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*presigned-url-sagemaker-notebook-role'
           - Effect: Allow
             Action:
               - s3:*
@@ -358,22 +370,22 @@ Resources:
               - config:*
               - servicecatalog:*
               - ec2-instance-connect:*
-            Resource: "*"
+            Resource: '*'
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
               - logs:CreateLogStream
               - logs:PutLogEvents
             Resource:
-              - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${Namespace}-*:*"
-              - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${Namespace}-*:log-stream:*"
+              - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${Namespace}-*:*'
+              - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${Namespace}-*:log-stream:*'
           - Effect: Allow
             Action:
               - iam:PassRole
-            Resource: "*"
+            Resource: '*'
             Condition:
               StringEquals:
-                iam:PassedToService: "servicecatalog.amazonaws.com"
+                iam:PassedToService: 'servicecatalog.amazonaws.com'
           - Effect: Allow
             Action:
               - iam:CreateRole
@@ -388,14 +400,14 @@ Resources:
               - iam:AttachRolePolicy
               - iam:DetachRolePolicy
             Resource:
-              - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${LaunchConstraintRolePrefix}"
-              - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*presigned-url-sagemaker-notebook-role"
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${LaunchConstraintRolePrefix}'
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*presigned-url-sagemaker-notebook-role'
           - Effect: Allow
             Action:
               - appstream:ListAssociatedFleets
               - appStream:CreateStreamingURL
             Resource:
-              - "*"
+              - '*'
           - Effect: Allow
             Action:
               - iam:CreatePolicy
@@ -405,7 +417,7 @@ Resources:
               - iam:DeletePolicy
               - iam:DeletePolicyVersion
             Resource:
-              - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${LaunchConstraintPolicyPrefix}"
+              - !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/${LaunchConstraintPolicyPrefix}'
           - Effect: Allow
             Action:
               - iam:GetGroup
@@ -414,22 +426,22 @@ Resources:
               - iam:ListGroups
               - iam:ListRoles
               - iam:ListUsers
-            Resource: "*" # These non-mutating IAM actions cover the permissions in managed policy AWSServiceCatalogAdminFullAccess
+            Resource: '*' # These non-mutating IAM actions cover the permissions in managed policy AWSServiceCatalogAdminFullAccess
           - !If
             - isAppStreamAndCustomDomain
             - Effect: Allow
               Action:
                 - route53:ChangeResourceRecordSets
               Resource:
-                - !Sub "arn:aws:route53:::hostedzone/${Route53HostedZone}"
-            - !Ref "AWS::NoValue"
+                - !Sub 'arn:aws:route53:::hostedzone/${Route53HostedZone}'
+            - !Ref 'AWS::NoValue'
 
   PolicyCrossAccountExecution:
     Type: AWS::IAM::ManagedPolicy
     Properties:
       Description: Allows main account to perform critical analytics on workspaces provisioned in member accounts
       PolicyDocument:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:
@@ -438,19 +450,19 @@ Resources:
               - cloudformation:DescribeStacks
               - cloudformation:DescribeStackEvents
             Resource:
-              - !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/SC-*"
-              - !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/analysis-*" # ALB stack used this pattern
+              - !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/SC-*'
+              - !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/analysis-*' # ALB stack used this pattern
           - Effect: Allow
             Action:
               - sagemaker:CreatePresignedNotebookInstanceUrl
               - sagemaker:StartNotebookInstance
               - sagemaker:StopNotebookInstance
               - sagemaker:DescribeNotebookInstance
-            Resource: !Sub "arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:notebook-instance/basicnotebookinstance-*"
+            Resource: !Sub 'arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:notebook-instance/basicnotebookinstance-*'
           - Effect: Allow
             Action:
               - sagemaker:ListNotebookInstances
-            Resource: "*" # For the actions listed above IAM does not support resource-level permissions and requires all resources to be chosen
+            Resource: '*' # For the actions listed above IAM does not support resource-level permissions and requires all resources to be chosen
           - Effect: Allow
             Action:
               - iam:GetRole
@@ -460,21 +472,21 @@ Resources:
               - iam:DeleteRole
               - iam:PassRole
               - iam:PutRolePolicy
-            Resource: !Sub "arn:aws:iam::${AWS::AccountId}:role/analysis-*"
+            Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:role/analysis-*'
           - Effect: Allow
             Action:
               - ce:GetCostAndUsage
-            Resource: "*" # For the actions listed above IAM does not support resource-level permissions and requires all resources to be chosen
+            Resource: '*' # For the actions listed above IAM does not support resource-level permissions and requires all resources to be chosen
           - Effect: Allow
             Action:
               - budgets:ViewBudget
               - budgets:ModifyBudget
-            Resource: !Sub "arn:aws:budgets::${AWS::AccountId}:budget/service-workbench-system-generated*"
+            Resource: !Sub 'arn:aws:budgets::${AWS::AccountId}:budget/service-workbench-system-generated*'
           - Effect: Allow
             Action:
               - ec2:StartInstances
               - ec2:StopInstances
-            Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+            Resource: !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*'
           - Effect: Allow
             Action:
               - ec2:DescribeInstanceStatus
@@ -482,7 +494,7 @@ Resources:
               - ec2:DescribeRouteTables
               - ec2:AssociateRouteTable
               - ec2:DisassociateRouteTable
-            Resource: "*" # For the actions listed above IAM does not support resource-level permissions and requires all resources to be chosen
+            Resource: '*' # For the actions listed above IAM does not support resource-level permissions and requires all resources to be chosen
           - Effect: Allow
             Action:
               - ec2:DescribeSubnets
@@ -494,12 +506,12 @@ Resources:
               - ec2:CreateTags
               - ec2:DeleteTags
               - ec2:DescribeInternetGateways
-            Resource: "*" # For the actions listed above IAM does not support resource-level permissions and requires all resources to be chosen
+            Resource: '*' # For the actions listed above IAM does not support resource-level permissions and requires all resources to be chosen
           - Effect: Allow
             Action:
               - ssm:GetParameter
             Resource:
-              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*"
+              - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*'
           - Effect: Allow
             Action:
               - ec2:CreateSubnet
@@ -508,8 +520,8 @@ Resources:
               - ec2:AssociateSubnetCidrBlock
               - ec2:DisassociateSubnetCidrBlock
             Resource:
-              - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:vpc/*"
-              - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:subnet/*"
+              - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:vpc/*'
+              - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:subnet/*'
           - Effect: Allow
             Action:
               - ec2:CreateSecurityGroup
@@ -517,8 +529,8 @@ Resources:
               - ec2:AuthorizeSecurityGroup*
               - ec2:RevokeSecurityGroup*
             Resource:
-              - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:vpc/*"
-              - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:security-group/*"
+              - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:vpc/*'
+              - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:security-group/*'
           - Effect: Allow
             Action:
               - elasticloadbalancing:DescribeLoadBalancers
@@ -527,7 +539,7 @@ Resources:
               - elasticloadbalancing:AddTags
               - elasticloadbalancing:RemoveTags
               - elasticloadbalancing:ModifyLoadBalancerAttributes
-            Resource: "*" # For the actions listed above IAM does not support resource-level permissions and requires all resources to be chosen
+            Resource: '*' # For the actions listed above IAM does not support resource-level permissions and requires all resources to be chosen
           - Effect: Allow
             Action:
               - elasticloadbalancing:CreateLoadBalancer
@@ -535,7 +547,7 @@ Resources:
               - elasticloadbalancing:SetSecurityGroups
               - elasticloadbalancing:SetSubnets
             Resource:
-              - !Sub "arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:loadbalancer/app/analysis-*"
+              - !Sub 'arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:loadbalancer/app/analysis-*'
           - Effect: Allow
             Action:
               - elasticloadbalancing:CreateListener
@@ -543,37 +555,37 @@ Resources:
               - elasticloadbalancing:AddListenerCertificates
               - elasticloadbalancing:RemoveListenerCertificates
             Resource:
-              - !Sub "arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:loadbalancer/app/analysis-*"
-              - !Sub "arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:listener/app/analysis-*"
+              - !Sub 'arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:loadbalancer/app/analysis-*'
+              - !Sub 'arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:listener/app/analysis-*'
           - Effect: Allow
             Action:
               - elasticloadbalancing:CreateRule
               - elasticloadbalancing:DeleteRule
               - elasticloadbalancing:ModifyRule
             Resource:
-              - !Sub "arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:listener/app/analysis-*"
-              - !Sub "arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:listener-rule/app/analysis-*"
+              - !Sub 'arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:listener/app/analysis-*'
+              - !Sub 'arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:listener-rule/app/analysis-*'
           - Effect: Allow
             Action:
               - iam:CreateServiceLinkedRole
             Resource:
-              - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing"
+              - !Sub 'arn:aws:iam::${AWS::AccountId}:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing'
   CrossAccountExecutionRole:
-    Type: "AWS::IAM::Role"
+    Type: 'AWS::IAM::Role'
     Properties:
-      RoleName: !Join ["-", [Ref: Namespace, "cross-account-role"]]
-      Path: "/"
+      RoleName: !Join ['-', [Ref: Namespace, 'cross-account-role']]
+      Path: '/'
       AssumeRolePolicyDocument:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement:
-          - Effect: "Allow"
+          - Effect: 'Allow'
             Principal:
               AWS:
-                - !Join [":", ["arn:aws:iam:", Ref: CentralAccountId, "root"]]
+                - !Join [':', ['arn:aws:iam:', Ref: CentralAccountId, 'root']]
                 - !Ref ApiHandlerArn
                 - !Ref WorkflowRoleArn
             Action:
-              - "sts:AssumeRole"
+              - 'sts:AssumeRole'
             Condition:
               StringEquals:
                 sts:ExternalId: !Ref ExternalId
@@ -582,19 +594,19 @@ Resources:
       PermissionsBoundary: !Ref PolicyCrossAccountExecution
 
   CfnStatusRole:
-    Type: "AWS::IAM::Role"
+    Type: 'AWS::IAM::Role'
     Properties:
-      RoleName: !Join ["-", [Ref: Namespace, "cfn-status-role"]]
-      Path: "/"
+      RoleName: !Join ['-', [Ref: Namespace, 'cfn-status-role']]
+      Path: '/'
       AssumeRolePolicyDocument:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement:
-          - Effect: "Allow"
+          - Effect: 'Allow'
             Principal:
               AWS:
-                - !Join [":", ["arn:aws:iam:", Ref: CentralAccountId, "root"]]
+                - !Join [':', ['arn:aws:iam:', Ref: CentralAccountId, 'root']]
             Action:
-              - "sts:AssumeRole"
+              - 'sts:AssumeRole'
             Condition:
               StringEquals:
                 sts:ExternalId: !Ref ExternalId
@@ -607,29 +619,29 @@ Resources:
     Properties:
       Description: Allows main account to onboard and check status of aws accounts
       PolicyDocument:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:
               - cloudformation:DescribeStacks
               - cloudformation:GetTemplate
-            Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/initial-stack*"
+            Resource: !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/initial-stack*'
 
   # This role is used by `infrastructure-tests`
   InfrastructureTestRole:
-    Type: "AWS::IAM::Role"
+    Type: 'AWS::IAM::Role'
     Properties:
-      RoleName: !Join ["-", [Ref: Namespace, "infrastructure-test-role"]]
-      Path: "/"
+      RoleName: !Join ['-', [Ref: Namespace, 'infrastructure-test-role']]
+      Path: '/'
       AssumeRolePolicyDocument:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement:
-          - Effect: "Allow"
+          - Effect: 'Allow'
             Principal:
               AWS:
-                - !Join [":", ["arn:aws:iam:", Ref: CentralAccountId, "root"]]
+                - !Join [':', ['arn:aws:iam:', Ref: CentralAccountId, 'root']]
             Action:
-              - "sts:AssumeRole"
+              - 'sts:AssumeRole'
             Condition:
               StringEquals:
                 sts:ExternalId: !Ref ExternalId
@@ -642,19 +654,19 @@ Resources:
     Properties:
       Description: Allows infrastructure tests to access hosting acccount CFN resources
       PolicyDocument:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Action:
               - cloudformation:DescribeStacks
               - cloudformation:DescribeStackResources
-            Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/initial-stack*"
+            Resource: !Sub 'arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/initial-stack*'
           - Effect: Allow
             Action:
               - ec2:DescribeSubnets
               - ec2:DescribeSecurityGroups
               - ec2:DescribeRouteTables
-            Resource: "*"
+            Resource: '*'
 
   # VPC for launching EMR clusters into
   # Just one AZ as we're aiming for transient low-cost clusters rather than HA
@@ -677,7 +689,7 @@ Resources:
       TrafficType: ACCEPT
       DeliverLogsPermissionArn: !GetAtt CrossAccountRoleEnvMgmt.Arn
       LogGroupName: !Ref FlowLogCloudwatchGroup
-      LogFormat: "${version} ${vpc-id} ${subnet-id} ${instance-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${tcp-flags} ${type} ${pkt-srcaddr} ${pkt-dstaddr}"
+      LogFormat: '${version} ${vpc-id} ${subnet-id} ${instance-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${tcp-flags} ${type} ${pkt-srcaddr} ${pkt-dstaddr}'
       Tags:
         - Key: Name
           Value: FlowLogForVPC
@@ -704,7 +716,7 @@ Resources:
     Condition: isNotAppStream
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [0, !GetAZs ""]
+      AvailabilityZone: !Select [0, !GetAZs '']
       CidrBlock: !Ref PublicSubnetCidr
       MapPublicIpOnLaunch: true
       Tags:
@@ -720,7 +732,7 @@ Resources:
       TrafficType: ACCEPT
       DeliverLogsPermissionArn: !GetAtt CrossAccountRoleEnvMgmt.Arn
       LogGroupName: !Ref FlowLogCloudwatchGroup
-      LogFormat: "${version} ${vpc-id} ${subnet-id} ${instance-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${tcp-flags} ${type} ${pkt-srcaddr} ${pkt-dstaddr}"
+      LogFormat: '${version} ${vpc-id} ${subnet-id} ${instance-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${tcp-flags} ${type} ${pkt-srcaddr} ${pkt-dstaddr}'
       Tags:
         - Key: Name
           Value: FlowLogForPublicSubnet1
@@ -755,48 +767,48 @@ Resources:
   EncryptionKey:
     Type: AWS::KMS::Key
     Properties:
-      Description: "This is the key used to secure resources in this account"
+      Description: 'This is the key used to secure resources in this account'
       EnableKeyRotation: True
       KeyPolicy:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement:
           - Sid: Allow root access
-            Effect: "Allow"
+            Effect: 'Allow'
             Principal:
               AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
             Action:
-              - "kms:*"
-            Resource: "*"
+              - 'kms:*'
+            Resource: '*'
           - Sid: Allow use of the key by this account
-            Effect: "Allow"
+            Effect: 'Allow'
             Principal:
-              AWS: "*"
+              AWS: '*'
             Action:
-              - "kms:DescribeKey"
-              - "kms:Encrypt"
-              - "kms:Decrypt"
-              - "kms:ReEncrypt*"
-              - "kms:GenerateDataKey"
-              - "kms:GenerateDataKeyWithoutPlaintext"
-              - "kms:CreateGrant"
-              - "kms:RevokeGrant"
-            Resource: "*"
+              - 'kms:DescribeKey'
+              - 'kms:Encrypt'
+              - 'kms:Decrypt'
+              - 'kms:ReEncrypt*'
+              - 'kms:GenerateDataKey'
+              - 'kms:GenerateDataKeyWithoutPlaintext'
+              - 'kms:CreateGrant'
+              - 'kms:RevokeGrant'
+            Resource: '*'
             Condition:
               StringEquals:
-                kms:CallerAccount: !Ref "AWS::AccountId"
+                kms:CallerAccount: !Ref 'AWS::AccountId'
 
   EncryptionKeyAlias:
     Type: AWS::KMS::Alias
     Properties:
-      AliasName: !Join ["", ["alias/", Ref: Namespace, "-encryption-key"]]
+      AliasName: !Join ['', ['alias/', Ref: Namespace, '-encryption-key']]
       TargetKeyId: !Ref EncryptionKey
 
   FlowLogCloudwatchGroup:
-    Type: "AWS::Logs::LogGroup"
+    Type: 'AWS::Logs::LogGroup'
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      LogGroupName: !Join ["", [Ref: Namespace, "-flow-logger"]]
+      LogGroupName: !Join ['', [Ref: Namespace, '-flow-logger']]
       RetentionInDays: 30
 
   #------------AppStream Resources Below-------
@@ -805,7 +817,7 @@ Resources:
     Condition: isAppStream
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [0, !GetAZs ""]
+      AvailabilityZone: !Select [0, !GetAZs '']
       CidrBlock: !Ref AppStreamSubnetCidr
       MapPublicIpOnLaunch: false
       Tags:
@@ -821,7 +833,7 @@ Resources:
       TrafficType: ACCEPT
       DeliverLogsPermissionArn: !GetAtt CrossAccountRoleEnvMgmt.Arn
       LogGroupName: !Ref FlowLogCloudwatchGroup
-      LogFormat: "${version} ${vpc-id} ${subnet-id} ${instance-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${tcp-flags} ${type} ${pkt-srcaddr} ${pkt-dstaddr}"
+      LogFormat: '${version} ${vpc-id} ${subnet-id} ${instance-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${tcp-flags} ${type} ${pkt-srcaddr} ${pkt-dstaddr}'
       Tags:
         - Key: Name
           Value: FlowLogPrivateAppStreamSubnet
@@ -833,7 +845,7 @@ Resources:
     Condition: isAppStream
     Properties:
       VpcId: !Ref VPC
-      AvailabilityZone: !Select [0, !GetAZs ""]
+      AvailabilityZone: !Select [0, !GetAZs '']
       CidrBlock: !Ref WorkspaceSubnetCidr
       MapPublicIpOnLaunch: false
       Tags:
@@ -849,7 +861,7 @@ Resources:
       TrafficType: ACCEPT
       DeliverLogsPermissionArn: !GetAtt CrossAccountRoleEnvMgmt.Arn
       LogGroupName: PrivateWorkspaceSubnetLogGroup
-      LogFormat: "${version} ${vpc-id} ${subnet-id} ${instance-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${tcp-flags} ${type} ${pkt-srcaddr} ${pkt-dstaddr}"
+      LogFormat: '${version} ${vpc-id} ${subnet-id} ${instance-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${tcp-flags} ${type} ${pkt-srcaddr} ${pkt-dstaddr}'
       Tags:
         - Key: Name
           Value: FlowLogForPrivateWorkspaceSubnet
@@ -857,13 +869,13 @@ Resources:
           Value: AcceptTraffic
 
   PrivateWorkspaceRouteTable:
-    Type: "AWS::EC2::RouteTable"
+    Type: 'AWS::EC2::RouteTable'
     Condition: isAppStream
     Properties:
       VpcId: !Ref VPC
 
   WorkspaceSubnetAssociationRouteTable:
-    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Type: 'AWS::EC2::SubnetRouteTableAssociation'
     Condition: isAppStream
     Properties:
       SubnetId: !Ref PrivateWorkspaceSubnet
@@ -871,89 +883,93 @@ Resources:
 
     # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcendpoint.html
   S3Endpoint:
-    Type: "AWS::EC2::VPCEndpoint"
+    Type: 'AWS::EC2::VPCEndpoint'
     Condition: isAppStream
     Properties:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
           - Effect: Allow
-            Principal: "*"
+            Principal: '*'
             Action:
-              - "s3:GetObject"
-              - "s3:GetObjectTagging"
-              - "s3:GetObjectTorrent"
-              - "s3:GetObjectVersion"
-              - "s3:GetObjectVersionTagging"
-              - "s3:GetObjectVersionTorrent"
-              - "s3:AbortMultipartUpload"
-              - "s3:ListMultipartUploadParts"
-              - "s3:PutObject"
-              - "s3:PutObjectAcl"
-              - "s3:PutObjectTagging"
-              - "s3:PutObjectVersionTagging"
-              - "s3:DeleteObject"
-              - "s3:DeleteObjectTagging"
-              - "s3:DeleteObjectVersion"
-              - "s3:DeleteObjectVersionTagging"
-              - "s3:ListBucket" # Required in get_bootstrap.sh when running `aws s3 sync`
+              - 's3:GetObject'
+              - 's3:GetObjectTagging'
+              - 's3:GetObjectTorrent'
+              - 's3:GetObjectVersion'
+              - 's3:GetObjectVersionTagging'
+              - 's3:GetObjectVersionTorrent'
+              - 's3:AbortMultipartUpload'
+              - 's3:ListMultipartUploadParts'
+              - 's3:PutObject'
+              - 's3:PutObjectAcl'
+              - 's3:PutObjectTagging'
+              - 's3:PutObjectVersionTagging'
+              - 's3:DeleteObject'
+              - 's3:DeleteObjectTagging'
+              - 's3:DeleteObjectVersion'
+              - 's3:DeleteObjectVersionTagging'
+              - 's3:ListBucket' # Required in get_bootstrap.sh when running `aws s3 sync`
             Resource:
-              - "*"
+              - '*'
       RouteTableIds:
         - !Ref PrivateWorkspaceRouteTable
-        - !If [isElasticAppStream, !Ref AppStreamSubnetRouteTable, !Ref 'AWS::NoValue']
+        - !If [
+            isElasticAppStream,
+            !Ref AppStreamSubnetRouteTable,
+            !Ref 'AWS::NoValue',
+          ]
       VpcEndpointType: Gateway
-      ServiceName: !Sub "com.amazonaws.${AWS::Region}.s3"
+      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.s3'
       VpcId: !Ref VPC
 
   KMSEndpoint:
-    Type: "AWS::EC2::VPCEndpoint"
+    Type: 'AWS::EC2::VPCEndpoint'
     Condition: isAppStream
     Properties:
       SubnetIds:
         - !Ref PrivateWorkspaceSubnet
       PrivateDnsEnabled: true
       VpcEndpointType: Interface
-      ServiceName: !Sub "com.amazonaws.${AWS::Region}.kms"
+      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.kms'
       VpcId: !Ref VPC
       SecurityGroupIds:
         - !Ref InterfaceEndpointSecurityGroup
 
   STSEndpoint:
-    Type: "AWS::EC2::VPCEndpoint"
+    Type: 'AWS::EC2::VPCEndpoint'
     Condition: isAppStream
     Properties:
       SubnetIds:
         - !Ref PrivateWorkspaceSubnet
       VpcEndpointType: Interface
       PrivateDnsEnabled: true
-      ServiceName: !Sub "com.amazonaws.${AWS::Region}.sts"
+      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.sts'
       VpcId: !Ref VPC
       SecurityGroupIds:
         - !Ref InterfaceEndpointSecurityGroup
 
   EC2Endpoint:
-    Type: "AWS::EC2::VPCEndpoint"
+    Type: 'AWS::EC2::VPCEndpoint'
     Condition: isAppStream
     Properties:
       SubnetIds:
         - !Ref PrivateWorkspaceSubnet
       VpcEndpointType: Interface
       PrivateDnsEnabled: true
-      ServiceName: !Sub "com.amazonaws.${AWS::Region}.ec2"
+      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.ec2'
       VpcId: !Ref VPC
       SecurityGroupIds:
         - !Ref InterfaceEndpointSecurityGroup
 
   CfnEndpoint:
-    Type: "AWS::EC2::VPCEndpoint"
+    Type: 'AWS::EC2::VPCEndpoint'
     Condition: isAppStream
     Properties:
       SubnetIds:
         - !Ref PrivateWorkspaceSubnet
       VpcEndpointType: Interface
       PrivateDnsEnabled: true
-      ServiceName: !Sub "com.amazonaws.${AWS::Region}.cloudformation"
+      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.cloudformation'
       VpcId: !Ref VPC
       SecurityGroupIds:
         - !Ref InterfaceEndpointSecurityGroup
@@ -962,8 +978,8 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Condition: isAppStream
     Properties:
-      GroupDescription: "Security Group for AppStream instances to connect with environments, and for environments to connect with interface endpoints"
-      GroupName: "Workspace-SG"
+      GroupDescription: 'Security Group for AppStream instances to connect with environments, and for environments to connect with interface endpoints'
+      GroupName: 'Workspace-SG'
       VpcId: !Ref VPC
 
   WorkspaceSecurityGroupIngress:
@@ -972,8 +988,8 @@ Resources:
     Properties:
       GroupId: !Ref WorkspaceSecurityGroup
       SourceSecurityGroupId: !Ref AppStreamSecurityGroup
-      Description: "Allow AppStream ingress from environments"
-      IpProtocol: "-1"
+      Description: 'Allow AppStream ingress from environments'
+      IpProtocol: '-1'
 
   WorkspaceSecurityGroupEgress:
     Type: AWS::EC2::SecurityGroupEgress
@@ -981,15 +997,15 @@ Resources:
     Properties:
       GroupId: !Ref WorkspaceSecurityGroup
       DestinationSecurityGroupId: !Ref InterfaceEndpointSecurityGroup
-      Description: "Allow Interface Endpoint egress from environments"
-      IpProtocol: "-1"
+      Description: 'Allow Interface Endpoint egress from environments'
+      IpProtocol: '-1'
 
   InterfaceEndpointSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Condition: isAppStream
     Properties:
-      GroupDescription: "Security Group for interface endpoints"
-      GroupName: "Interface-Endpoint-SG"
+      GroupDescription: 'Security Group for interface endpoints'
+      GroupName: 'Interface-Endpoint-SG'
       VpcId: !Ref VPC
 
   InterfaceEndpointSecurityGroupIngress:
@@ -998,45 +1014,45 @@ Resources:
     Properties:
       GroupId: !Ref InterfaceEndpointSecurityGroup
       SourceSecurityGroupId: !Ref WorkspaceSecurityGroup
-      Description: "Allow environment ingress from interface endpoints"
-      IpProtocol: "-1"
+      Description: 'Allow environment ingress from interface endpoints'
+      IpProtocol: '-1'
 
   SSMEndpoint:
-    Type: "AWS::EC2::VPCEndpoint"
+    Type: 'AWS::EC2::VPCEndpoint'
     Condition: isAppStreamAndCustomDomain
     Properties:
       SubnetIds:
         - !Ref PrivateWorkspaceSubnet
       VpcEndpointType: Interface
       PrivateDnsEnabled: true
-      ServiceName: !Sub "com.amazonaws.${AWS::Region}.ssm"
+      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.ssm'
       VpcId: !Ref VPC
       SecurityGroupIds:
         - !Ref InterfaceEndpointSecurityGroup
 
     # https://docs.aws.amazon.com/sagemaker/latest/dg/notebook-interface-endpoint.html
   SagemakerNotebookEndpoint:
-    Type: "AWS::EC2::VPCEndpoint"
+    Type: 'AWS::EC2::VPCEndpoint'
     Condition: isAppStream
     Properties:
       SubnetIds:
         - !Ref PrivateAppStreamSubnet
       VpcEndpointType: Interface
       PrivateDnsEnabled: true
-      ServiceName: !Sub "aws.sagemaker.${AWS::Region}.notebook"
+      ServiceName: !Sub 'aws.sagemaker.${AWS::Region}.notebook'
       SecurityGroupIds:
         - !Ref SageMakerSecurityGroup
       VpcId: !Ref VPC
 
   SagemakerApiEndpoint:
-    Type: "AWS::EC2::VPCEndpoint"
+    Type: 'AWS::EC2::VPCEndpoint'
     Condition: isAppStream
     Properties:
       SubnetIds:
         - !Ref PrivateWorkspaceSubnet
       VpcEndpointType: Interface
       PrivateDnsEnabled: true
-      ServiceName: !Sub "com.amazonaws.${AWS::Region}.sagemaker.api"
+      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.sagemaker.api'
       VpcId: !Ref VPC
       SecurityGroupIds:
         - !Ref SagemakerApiEndpointSecurityGroup
@@ -1045,42 +1061,41 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Condition: isAppStream
     Properties:
-      GroupDescription: "Sagemaker Api Endpoint Security Group for interface endpoint"
-      GroupName: "Sagemaker-API-SG"
+      GroupDescription: 'Sagemaker Api Endpoint Security Group for interface endpoint'
+      GroupName: 'Sagemaker-API-SG'
       VpcId: !Ref VPC
       SecurityGroupIngress:
         - SourceSecurityGroupId: !Ref WorkspaceSecurityGroup
-          IpProtocol: "-1"
+          IpProtocol: '-1'
 
   SageMakerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Condition: isAppStream
     Properties:
-      GroupDescription: "SWB SageMaker Security Group for interface endpoint"
-      GroupName: "SageMakerSG"
+      GroupDescription: 'SWB SageMaker Security Group for interface endpoint'
+      GroupName: 'SageMakerSG'
       VpcId: !Ref VPC
       SecurityGroupIngress:
         - SourceSecurityGroupId: !Ref AppStreamSecurityGroup
-          IpProtocol: "-1"
+          IpProtocol: '-1'
 
   AppStreamSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Condition: isAppStream
     Properties:
-      GroupDescription: "SWB AppStream Security Group"
-      GroupName: "AppStreamSG"
+      GroupDescription: 'SWB AppStream Security Group'
+      GroupName: 'AppStreamSG'
       VpcId: !Ref VPC
       SecurityGroupEgress:
         - CidrIp: 127.0.0.1/32
-          IpProtocol: "-1"
+          IpProtocol: '-1'
         - DestinationSecurityGroupId: !Ref WorkspaceSecurityGroup
-          IpProtocol: "-1"
+          IpProtocol: '-1'
         - !If
           - isElasticAppStream
           - DestinationPrefixListId: !Ref S3PrefixList
             IpProtocol: '-1'
-          - !Ref "AWS::NoValue"
-
+          - !Ref 'AWS::NoValue'
 
   AppStreamSecurityGroupEgress:
     Type: AWS::EC2::SecurityGroupEgress
@@ -1088,8 +1103,8 @@ Resources:
     Properties:
       GroupId: !Ref AppStreamSecurityGroup
       DestinationSecurityGroupId: !Ref SageMakerSecurityGroup
-      Description: "Allow SageMaker egress from AppStream instances"
-      IpProtocol: "-1"
+      Description: 'Allow SageMaker egress from AppStream instances'
+      IpProtocol: '-1'
 
   SageMakerSecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
@@ -1097,8 +1112,8 @@ Resources:
     Properties:
       GroupId: !Ref SageMakerSecurityGroup
       SourceSecurityGroupId: !Ref AppStreamSecurityGroup
-      Description: "Allow AppStream ingress from interface endpoint of SageMaker"
-      IpProtocol: "-1"
+      Description: 'Allow AppStream ingress from interface endpoint of SageMaker'
+      IpProtocol: '-1'
 
   AppStreamSubnet2:
     Type: AWS::EC2::Subnet
@@ -1106,7 +1121,7 @@ Resources:
     Properties:
       VpcId: !Ref VPC
       AvailabilityZone: !Select [1, !GetAZs '']
-      CidrBlock: !Select [ 3, !Cidr [ !Ref VpcCidr, 4, 13 ]]
+      CidrBlock: !Select [3, !Cidr [!Ref VpcCidr, 4, 13]]
       MapPublicIpOnLaunch: false
       Tags:
         - Key: Name
@@ -1136,49 +1151,56 @@ Resources:
       SubnetId: !Ref AppStreamSubnet2
 
   AppStreamInstanceRole:
-    Type: "AWS::IAM::Role"
+    Type: 'AWS::IAM::Role'
     Condition: isElasticAppStream
     Properties:
-      RoleName: !Join ["-", [Ref: Namespace, "appstream-instance"]]
+      RoleName: !Join ['-', [Ref: Namespace, 'appstream-instance']]
       AssumeRolePolicyDocument:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement:
-          - Effect: "Allow"
+          - Effect: 'Allow'
             Principal:
-              Service: "appstream.amazonaws.com"
+              Service: 'appstream.amazonaws.com'
             Action:
-              - "sts:AssumeRole"
+              - 'sts:AssumeRole'
 
   AppStreamFleet:
-    Type: "AWS::AppStream::Fleet"
+    Type: 'AWS::AppStream::Fleet'
     Condition: isAppStream
     Properties:
-      ComputeCapacity:
-        !If
+      ComputeCapacity: !If
         - isNotElasticAppStream
-        -
-          DesiredInstances: !Ref AppStreamFleetDesiredInstances
+        - DesiredInstances: !Ref AppStreamFleetDesiredInstances
         - !Ref 'AWS::NoValue'
-      Description: "SWB AppStream Fleet"
+      Description: 'SWB AppStream Fleet'
       DisconnectTimeoutInSeconds: !Ref AppStreamDisconnectTimeoutSeconds
-      DisplayName: "SWB Fleet"
+      DisplayName: 'SWB Fleet'
       EnableDefaultInternetAccess: False
       FleetType: !Ref AppStreamFleetType
       IdleDisconnectTimeoutInSeconds: !Ref AppStreamIdleDisconnectTimeoutSeconds
-      ImageArn:
-        !If
+      ImageArn: !If
         - amiSharingEnabled
-        - !Sub "arn:aws:appstream:${AWS::Region}:${DevopsAccountId}:image/${AppStreamImageName}"
+        - !Sub 'arn:aws:appstream:${AWS::Region}:${DevopsAccountId}:image/${AppStreamImageName}'
         - !If
           - notAmiSharingEnabled
-          - !Sub "arn:aws:appstream:${AWS::Region}:${CentralAccountId}:image/${AppStreamImageName}"
+          - !Sub 'arn:aws:appstream:${AWS::Region}:${CentralAccountId}:image/${AppStreamImageName}'
           - !Ref 'AWS::NoValue'
       InstanceType: !Ref AppStreamInstanceType
       MaxUserDurationInSeconds: !Ref AppStreamMaxUserDurationSeconds
       Name: !Sub ${Namespace}-ServiceWorkbenchFleet
-      StreamView: "APP"
-      MaxConcurrentSessions: !If [isElasticAppStream, !Ref AppStreamMaxConcurrentSessions, !Ref 'AWS::NoValue']
-      IamRoleArn: !If [isElasticAppStream, !GetAtt AppStreamInstanceRole.Arn, !Ref 'AWS::NoValue']
+      StreamView: 'APP'
+      MaxConcurrentSessions:
+        !If [
+          isElasticAppStream,
+          !Ref AppStreamMaxConcurrentSessions,
+          !Ref 'AWS::NoValue',
+        ]
+      IamRoleArn:
+        !If [
+          isElasticAppStream,
+          !GetAtt AppStreamInstanceRole.Arn,
+          !Ref 'AWS::NoValue',
+        ]
       Platform: !If [isElasticAppStream, 'AMAZON_LINUX2', !Ref 'AWS::NoValue']
       VpcConfig:
         SecurityGroupIds:
@@ -1190,25 +1212,25 @@ Resources:
       StartFleet: True
 
   AppStreamStack:
-    Type: "AWS::AppStream::Stack"
+    Type: 'AWS::AppStream::Stack'
     Condition: isAppStream
     Properties:
       ApplicationSettings:
         Enabled: False
-      Description: "SWB AppStream Stack"
-      DisplayName: "SWB Stack"
+      Description: 'SWB AppStream Stack'
+      DisplayName: 'SWB Stack'
       Name: !Sub ${Namespace}-ServiceWorkbenchStack
       UserSettings:
-        - Action: "CLIPBOARD_COPY_FROM_LOCAL_DEVICE"
-          Permission: "ENABLED"
-        - Action: "CLIPBOARD_COPY_TO_LOCAL_DEVICE"
-          Permission: "DISABLED"
-        - Action: "FILE_DOWNLOAD"
-          Permission: "DISABLED"
-        - Action: "FILE_UPLOAD"
-          Permission: "DISABLED"
-        - Action: "PRINTING_TO_LOCAL_DEVICE"
-          Permission: "DISABLED"
+        - Action: 'CLIPBOARD_COPY_FROM_LOCAL_DEVICE'
+          Permission: 'ENABLED'
+        - Action: 'CLIPBOARD_COPY_TO_LOCAL_DEVICE'
+          Permission: 'DISABLED'
+        - Action: 'FILE_DOWNLOAD'
+          Permission: 'DISABLED'
+        - Action: 'FILE_UPLOAD'
+          Permission: 'DISABLED'
+        - Action: 'PRINTING_TO_LOCAL_DEVICE'
+          Permission: 'DISABLED'
 
   AppStreamStackFleetAssociation:
     Type: AWS::AppStream::StackFleetAssociation
@@ -1264,7 +1286,7 @@ Outputs:
     Condition: isAppStream
     Value: !Ref AppStreamSecurityGroup
     Export:
-      Name: !Join ["", [Ref: Namespace, "-SwbAppStreamSG"]]
+      Name: !Join ['', [Ref: Namespace, '-SwbAppStreamSG']]
 
   SageMakerSecurityGroup:
     Description: SageMaker Security Group
@@ -1291,14 +1313,14 @@ Outputs:
     Condition: isAppStream
     Value: !Ref InterfaceEndpointSecurityGroup
     Export:
-      Name: !Join ["", [Ref: Namespace, "-InterfaceEndpointSG"]]
+      Name: !Join ['', [Ref: Namespace, '-InterfaceEndpointSG']]
 
   WorkspaceSG:
     Description: Security Group for AppStream instances to connect with environments, and for environments to connect with interface endpoints
     Condition: isAppStream
     Value: !Ref WorkspaceSecurityGroup
     Export:
-      Name: !Join ["", [Ref: Namespace, "-WorkspaceSG"]]
+      Name: !Join ['', [Ref: Namespace, '-WorkspaceSG']]
 
   AppStreamStackName:
     Description: Name of the stack created by AppStream
@@ -1310,14 +1332,14 @@ Outputs:
     Condition: isAppStream
     Value: !Ref SagemakerNotebookEndpoint
     Export:
-      Name: !Join ["", [Ref: Namespace, "-SageMakerVPCE"]]
+      Name: !Join ['', [Ref: Namespace, '-SageMakerVPCE']]
 
   SageMakerApiSG:
     Description: SageMaker API SG
     Condition: isAppStream
     Value: !Ref SagemakerApiEndpointSecurityGroup
     Export:
-      Name: !Join ["", [Ref: Namespace, "-SageMakerApiSecurityGroup"]]
+      Name: !Join ['', [Ref: Namespace, '-SageMakerApiSecurityGroup']]
 
   Route53HostedZone:
     Description: Route53 hosted zone

--- a/src/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/src/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -175,10 +175,8 @@ Conditions:
     - !Not [!Equals [!Ref 'DomainName', '']]
     - !Condition isAppStream
   enableFlowLogs: !Equals [!Ref EnableFlowLogs, true]
-  enableFlowLogsNonAppStream:
-    !And [Condition: isNotAppStream, Condition: enableFlowLogs]
-  enableFlowLogsWithAppStream:
-    !And [Condition: isAppStream, Condition: enableFlowLogs]
+  enableFlowLogsNonAppStream: !And [Condition: isNotAppStream,Condition: enableFlowLogs]
+  enableFlowLogsWithAppStream: !And [Condition: isAppStream,Condition: enableFlowLogs]
   amiSharingEnabled:
     !And [
       !Equals [!Ref 'EnableAmiSharing', true],

--- a/src/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-connection-service.js
+++ b/src/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-connection-service.js
@@ -169,10 +169,7 @@ class EnvironmentScConnectionService extends Service {
     const connection = await this.mustFindConnection(requestContext, envId, connectionId);
 
     // Write audit event
-    await this.audit(requestContext, {
-      action: 'env-presigned-url-requested',
-      body: { id: envId, connection },
-    });
+    await this.audit(requestContext, { action: 'env-presigned-url-requested', body: { id: envId, connection } });
 
     if (!_.isEmpty(connection.url)) {
       // if connection already has url then just return it
@@ -180,9 +177,7 @@ class EnvironmentScConnectionService extends Service {
     }
 
     // Verify environment is linked to an AppStream project when application has AppStream enabled
-    const { projectId } = await environmentScService.mustFind(requestContext, {
-      id: envId,
-    });
+    const { projectId } = await environmentScService.mustFind(requestContext, { id: envId });
     await environmentScService.verifyAppStreamConfig(requestContext, projectId);
 
     if (_.toLower(_.get(connection, 'type', '')) === 'sagemaker') {
@@ -250,10 +245,7 @@ class EnvironmentScConnectionService extends Service {
     const publicKeyObject = key.importKey({ n: modulusBuffer, e: exponentBuffer }, 'components-public');
     const payloadBuffer = Buffer.from(credentials);
     const result = crypto.publicEncrypt(
-      {
-        key: publicKeyObject.exportKey('public'),
-        padding: crypto.constants.RSA_PKCS1_PADDING,
-      },
+      { key: publicKeyObject.exportKey('public'), padding: crypto.constants.RSA_PKCS1_PADDING },
       payloadBuffer,
     );
     const params = { v: result.toString('base64') };
@@ -290,9 +282,7 @@ class EnvironmentScConnectionService extends Service {
     await validationService.ensureValid(sshConnectionInfo, sshConnectionInfoSchema);
 
     // Verify environment is linked to an AppStream project when application has AppStream enabled
-    const { projectId } = await environmentScService.mustFind(requestContext, {
-      id: envId,
-    });
+    const { projectId } = await environmentScService.mustFind(requestContext, { id: envId });
     await environmentScService.verifyAppStreamConfig(requestContext, projectId);
 
     // The following will succeed only if the user has permissions to access the specified environment
@@ -329,10 +319,7 @@ class EnvironmentScConnectionService extends Service {
       environmentScService.getClientSdkWithEnvMgmtRole(
         requestContext,
         { id: envId },
-        {
-          clientName: 'EC2InstanceConnect',
-          options: { apiVersion: '2018-04-02' },
-        },
+        { clientName: 'EC2InstanceConnect', options: { apiVersion: '2018-04-02' } },
       ),
     ]);
 
@@ -368,9 +355,7 @@ class EnvironmentScConnectionService extends Service {
     ]);
 
     // Verify environment is linked to an AppStream project when application has AppStream enabled
-    const { projectId } = await environmentScService.mustFind(requestContext, {
-      id: envId,
-    });
+    const { projectId } = await environmentScService.mustFind(requestContext, { id: envId });
     await environmentScService.verifyAppStreamConfig(requestContext, projectId);
 
     // The following will succeed only if the user has permissions to access the specified environment

--- a/src/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-connection-service.js
+++ b/src/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-connection-service.js
@@ -13,47 +13,40 @@
  *  permissions and limitations under the License.
  */
 
-const _ = require("lodash");
-let fetch = require("node-fetch");
-const crypto = require("crypto");
-const NodeRSA = require("node-rsa");
-const querystring = require("querystring");
-const Service = require("@amzn/base-services-container/lib/service");
-const {
-  retry,
-  linearInterval,
-} = require("@amzn/base-services/lib/helpers/utils");
-const sshConnectionInfoSchema = require("../../schema/ssh-connection-info-sc");
-const { connectionScheme } = require("./environment-sc-connection-enum");
-const { cfnOutputsToConnections } = require("./helpers/connections-util");
+const _ = require('lodash');
+let fetch = require('node-fetch');
+const crypto = require('crypto');
+const NodeRSA = require('node-rsa');
+const querystring = require('querystring');
+const Service = require('@amzn/base-services-container/lib/service');
+const { retry, linearInterval } = require('@amzn/base-services/lib/helpers/utils');
+const sshConnectionInfoSchema = require('../../schema/ssh-connection-info-sc');
+const { connectionScheme } = require('./environment-sc-connection-enum');
+const { cfnOutputsToConnections } = require('./helpers/connections-util');
 
 // Webpack messes with the fetch function import and it breaks in lambda.
-if (
-  typeof fetch !== "function" &&
-  fetch.default &&
-  typeof fetch.default === "function"
-) {
+if (typeof fetch !== 'function' && fetch.default && typeof fetch.default === 'function') {
   fetch = fetch.default;
 }
 
 const settingKeys = {
-  restrictAdminWorkspaceConnection: "restrictAdminWorkspaceConnection",
+  restrictAdminWorkspaceConnection: 'restrictAdminWorkspaceConnection',
 };
 
 class EnvironmentScConnectionService extends Service {
   constructor() {
     super();
     this.dependency([
-      "environmentScService",
-      "environmentScKeypairService",
-      "environmentDnsService",
-      "jsonSchemaValidationService",
-      "jwtService",
-      "keyPairService",
-      "auditWriterService",
-      "pluginRegistryService",
-      "lockService",
-      "aws",
+      'environmentScService',
+      'environmentScKeypairService',
+      'environmentDnsService',
+      'jsonSchemaValidationService',
+      'jwtService',
+      'keyPairService',
+      'auditWriterService',
+      'pluginRegistryService',
+      'lockService',
+      'aws',
     ]);
   }
 
@@ -99,12 +92,11 @@ class EnvironmentScConnectionService extends Service {
    */
   async listConnections(requestContext, envId) {
     const [environmentScService, pluginRegistryService] = await this.service([
-      "environmentScService",
-      "pluginRegistryService",
+      'environmentScService',
+      'pluginRegistryService',
     ]);
     // The following will succeed only if the user has permissions to access the specified environment
-    const { outputs, projectId, createdBy } =
-      await environmentScService.mustFind(requestContext, { id: envId });
+    const { outputs, projectId, createdBy } = await environmentScService.mustFind(requestContext, { id: envId });
     // Restrict the admin to access workspace not owned by them.
     this.verifyAccess(requestContext, createdBy);
     // Verify environment is linked to an AppStream project when application has AppStream enabled
@@ -115,41 +107,37 @@ class EnvironmentScConnectionService extends Service {
 
     // Give plugins chance to adjust the connection (such as connection url etc)
     const adjustedConnections = await Promise.all(
-      _.map(result, async (connection) => {
+      _.map(result, async connection => {
         // This is done so that plugins know it was called during list connections cycle
-        connection.operation = "list";
+        connection.operation = 'list';
 
         const pluginsResult = await pluginRegistryService.visitPlugins(
-          "env-sc-connection-url",
-          "createConnectionUrl",
+          'env-sc-connection-url',
+          'createConnectionUrl',
           {
             payload: {
               envId,
               connection,
             },
           },
-          { requestContext, container: this.container }
+          { requestContext, container: this.container },
         );
 
-        return _.get(pluginsResult, "connection", connection);
-      })
+        return _.get(pluginsResult, 'connection', connection);
+      }),
     );
     return adjustedConnections;
   }
 
   verifyAccess(requestContext, createdBy) {
     const restrictAdminWorkspaceConnection =
-      this.settings.getBoolean(settingKeys.restrictAdminWorkspaceConnection) ||
-      false;
+      this.settings.getBoolean(settingKeys.restrictAdminWorkspaceConnection) || false;
     if (!restrictAdminWorkspaceConnection) return true;
 
-    const uid = _.get(requestContext, "principalIdentifier.uid");
-    const isAdmin = _.get(requestContext, "principal.isAdmin");
+    const uid = _.get(requestContext, 'principalIdentifier.uid');
+    const isAdmin = _.get(requestContext, 'principal.isAdmin');
     if (isAdmin && uid !== createdBy) {
-      throw this.boom.notFound(
-        `You do not have access to other user's workspace`,
-        true
-      );
+      throw this.boom.notFound(`You do not have access to other user's workspace`, true);
     }
 
     return true;
@@ -163,37 +151,26 @@ class EnvironmentScConnectionService extends Service {
   }
 
   async mustFindConnection(requestContext, envId, connectionId) {
-    const connection = await this.findConnection(
-      requestContext,
-      envId,
-      connectionId
-    );
+    const connection = await this.findConnection(requestContext, envId, connectionId);
     if (_.isEmpty(connection)) {
-      throw this.boom.notFound(
-        `The connection with id "${connectionId}" was not found`,
-        true
-      );
+      throw this.boom.notFound(`The connection with id "${connectionId}" was not found`, true);
     }
     return connection;
   }
 
   async createConnectionUrl(requestContext, envId, connectionId) {
     const [environmentScService, pluginRegistryService] = await this.service([
-      "environmentScService",
-      "pluginRegistryService",
+      'environmentScService',
+      'pluginRegistryService',
     ]);
 
     // The following will succeed only if the user has permissions to access the specified environment
     // and connection
-    const connection = await this.mustFindConnection(
-      requestContext,
-      envId,
-      connectionId
-    );
+    const connection = await this.mustFindConnection(requestContext, envId, connectionId);
 
     // Write audit event
     await this.audit(requestContext, {
-      action: "env-presigned-url-requested",
+      action: 'env-presigned-url-requested',
       body: { id: envId, connection },
     });
 
@@ -208,105 +185,89 @@ class EnvironmentScConnectionService extends Service {
     });
     await environmentScService.verifyAppStreamConfig(requestContext, projectId);
 
-    if (_.toLower(_.get(connection, "type", "")) === "sagemaker") {
+    if (_.toLower(_.get(connection, 'type', '')) === 'sagemaker') {
       const sagemaker = await environmentScService.getClientSdkWithEnvMgmtRole(
         requestContext,
         { id: envId },
-        { clientName: "SageMaker", options: { apiVersion: "2017-07-24" } }
+        { clientName: 'SageMaker', options: { apiVersion: '2017-07-24' } },
       );
 
       const params = {
         NotebookInstanceName: connection.info,
       };
-      const sageMakerResponse = await sagemaker
-        .createPresignedNotebookInstanceUrl(params)
-        .promise();
+      const sageMakerResponse = await sagemaker.createPresignedNotebookInstanceUrl(params).promise();
       this.log.info();
-      connection.url = _.get(sageMakerResponse, "AuthorizedUrl").replace(
-        "?",
-        "/lab?"
-      );
+      connection.url = _.get(sageMakerResponse, 'AuthorizedUrl').replace('?', '/lab?');
     }
 
     if (
-      _.toLower(_.get(connection, "type", "")) === "rstudio" ||
-      _.toLower(_.get(connection, "type", "")) === "rstudiov2"
+      _.toLower(_.get(connection, 'type', '')) === 'rstudio' ||
+      _.toLower(_.get(connection, 'type', '')) === 'rstudiov2'
     ) {
-      connection.url = await this.getRStudioUrl(
-        requestContext,
-        envId,
-        connection
-      );
+      connection.url = await this.getRStudioUrl(requestContext, envId, connection);
     }
 
     // This is done so that plugins know it was called during create URL cycle
-    connection.operation = "create";
+    connection.operation = 'create';
     // Give plugins chance to adjust the connection (such as connection url etc)
     const result = await pluginRegistryService.visitPlugins(
-      "env-sc-connection-url",
-      "createConnectionUrl",
+      'env-sc-connection-url',
+      'createConnectionUrl',
       {
         payload: {
           envId,
           connection,
         },
       },
-      { requestContext, container: this.container }
+      { requestContext, container: this.container },
     );
 
-    return _.get(result, "connection") || connection;
+    return _.get(result, 'connection') || connection;
   }
 
   async getRStudioUrl(requestContext, id, connection) {
-    if (_.toLower(_.get(connection, "type", "")) === "rstudio")
+    if (_.toLower(_.get(connection, 'type', '')) === 'rstudio')
       throw this.boom.badRequest(
-        "Support for this version of RStudio has been deprecated. Please use RStudioV2 environment type",
-        true
+        'Support for this version of RStudio has been deprecated. Please use RStudioV2 environment type',
+        true,
       );
 
-    const environmentDnsService = await this.service("environmentDnsService");
-    const rstudioDomainName = environmentDnsService.getHostname("rstudio", id);
+    const environmentDnsService = await this.service('environmentDnsService');
+    const rstudioDomainName = environmentDnsService.getHostname('rstudio', id);
     const rstudioSignInUrl = `https://${rstudioDomainName}/auth-do-sign-in`;
     const instanceId = connection.instanceId;
-    const jwtService = await this.service("jwtService");
+    const jwtService = await this.service('jwtService');
     const jwtSecret = await jwtService.getSecret();
-    const hash = crypto.createHash("sha256");
-    const username = "rstudio-user";
-    const password = hash.update(`${instanceId}${jwtSecret}`).digest("hex");
+    const hash = crypto.createHash('sha256');
+    const username = 'rstudio-user';
+    const password = hash.update(`${instanceId}${jwtSecret}`).digest('hex');
     const credentials = `${username}\n${password}`;
-    const publicKey = await this.getRstudioPublicKey(
-      requestContext,
-      instanceId,
-      id
-    );
-    const [exponent, modulus] = publicKey.split(":", 2);
-    const exponentBuffer = Buffer.from(exponent, "hex");
-    const modulusBuffer = Buffer.from(modulus, "hex");
+    const publicKey = await this.getRstudioPublicKey(requestContext, instanceId, id);
+    const [exponent, modulus] = publicKey.split(':', 2);
+    const exponentBuffer = Buffer.from(exponent, 'hex');
+    const modulusBuffer = Buffer.from(modulus, 'hex');
     const key = new NodeRSA();
-    const publicKeyObject = key.importKey(
-      { n: modulusBuffer, e: exponentBuffer },
-      "components-public"
-    );
+    const publicKeyObject = key.importKey({ n: modulusBuffer, e: exponentBuffer }, 'components-public');
     const payloadBuffer = Buffer.from(credentials);
     const result = crypto.publicEncrypt(
       {
-        key: publicKeyObject.exportKey("public"),
+        key: publicKeyObject.exportKey('public'),
         padding: crypto.constants.RSA_PKCS1_PADDING,
       },
-      payloadBuffer
+      payloadBuffer,
     );
-    const params = { v: result.toString("base64") };
+    const params = { v: result.toString('base64') };
     const authorizedUrl = `${rstudioSignInUrl}?${querystring.encode(params)}`;
     return authorizedUrl;
   }
 
   async getRstudioPublicKey(requestContext, instanceId, id) {
-    const environmentScService = await this.service("environmentScService");
+    const environmentScService = await this.service('environmentScService');
 
     const ssm = await environmentScService.getClientSdkWithEnvMgmtRole(
       requestContext,
       { id },
-      { clientName: "SSM", options: { apiVersion: "2014-11-06" } }
+      { clientName: 'SSM', options: { apiVersion: '2014-11-06' } },
     );
     const rstudioPublicKey = await ssm
       .getParameter({
@@ -318,24 +279,15 @@ class EnvironmentScConnectionService extends Service {
     return rstudioPublicKey.Parameter.Value;
   }
 
-  async sendSshPublicKey(
-    requestContext,
-    envId,
-    connectionId,
-    sshConnectionInfo
-  ) {
-    const [environmentScService, keyPairService, validationService] =
-      await this.service([
-        "environmentScService",
-        "keyPairService",
-        "jsonSchemaValidationService",
-      ]);
+  async sendSshPublicKey(requestContext, envId, connectionId, sshConnectionInfo) {
+    const [environmentScService, keyPairService, validationService] = await this.service([
+      'environmentScService',
+      'keyPairService',
+      'jsonSchemaValidationService',
+    ]);
 
     // Validate input
-    await validationService.ensureValid(
-      sshConnectionInfo,
-      sshConnectionInfoSchema
-    );
+    await validationService.ensureValid(sshConnectionInfo, sshConnectionInfoSchema);
 
     // Verify environment is linked to an AppStream project when application has AppStream enabled
     const { projectId } = await environmentScService.mustFind(requestContext, {
@@ -344,36 +296,26 @@ class EnvironmentScConnectionService extends Service {
     await environmentScService.verifyAppStreamConfig(requestContext, projectId);
 
     // The following will succeed only if the user has permissions to access the specified environment
-    const connection = await this.mustFindConnection(
-      requestContext,
-      envId,
-      connectionId
-    );
+    const connection = await this.mustFindConnection(requestContext, envId, connectionId);
 
     if (connection.scheme !== connectionScheme.ssh) {
       throw this.boom.badRequest(
         `The connection "${connectionId}" does not support SSH. Please contact your administrator.`,
-        true
+        true,
       );
     }
     if (_.isEmpty(connection.instanceId)) {
       throw this.boom.badRequest(
         `Could not determine the EC2 instance to SSH to for the connection "${connectionId}". This is most likely due to incorrect AWS CloudFormation output. Please contact your administrator.`,
-        true
+        true,
       );
     }
 
     const { keyPairId } = sshConnectionInfo;
     // keyPairService.mustFind will only succeed if the caller has permissions to read the key with keyPairId
-    const { publicKey, status } = await keyPairService.mustFind(
-      requestContext,
-      { id: keyPairId }
-    );
-    if (_.toLower(status) !== "active") {
-      throw this.boom.badRequest(
-        `Cannot use key pair ${keyPairId}. The key is not active.`,
-        true
-      );
+    const { publicKey, status } = await keyPairService.mustFind(requestContext, { id: keyPairId });
+    if (_.toLower(status) !== 'active') {
+      throw this.boom.badRequest(`Cannot use key pair ${keyPairId}. The key is not active.`, true);
     }
 
     const instanceId = connection.instanceId;
@@ -382,36 +324,34 @@ class EnvironmentScConnectionService extends Service {
       environmentScService.getClientSdkWithEnvMgmtRole(
         requestContext,
         { id: envId },
-        { clientName: "EC2", options: { apiVersion: "2016-11-15" } }
+        { clientName: 'EC2', options: { apiVersion: '2016-11-15' } },
       ),
       environmentScService.getClientSdkWithEnvMgmtRole(
         requestContext,
         { id: envId },
         {
-          clientName: "EC2InstanceConnect",
-          options: { apiVersion: "2018-04-02" },
-        }
+          clientName: 'EC2InstanceConnect',
+          options: { apiVersion: '2018-04-02' },
+        },
       ),
     ]);
 
-    const data = await ec2Sdk
-      .describeInstances({ InstanceIds: [instanceId] })
-      .promise();
-    const instanceInfo = _.get(data, "Reservations[0].Instances[0]");
-    const instanceAz = _.get(instanceInfo || {}, "Placement.AvailabilityZone");
+    const data = await ec2Sdk.describeInstances({ InstanceIds: [instanceId] }).promise();
+    const instanceInfo = _.get(data, 'Reservations[0].Instances[0]');
+    const instanceAz = _.get(instanceInfo || {}, 'Placement.AvailabilityZone');
 
     await ec2InstanceConnectSdk
       .sendSSHPublicKey({
         AvailabilityZone: instanceAz,
         InstanceId: instanceId,
-        InstanceOSUser: sshConnectionInfo.instanceOsUser || "ec2-user", // This should be the user you wish to be when ssh-ing to the instance (eg, ec2-user@[instance IP]). Defaults to "ec2-user"
+        InstanceOSUser: sshConnectionInfo.instanceOsUser || 'ec2-user', // This should be the user you wish to be when ssh-ing to the instance (eg, ec2-user@[instance IP]). Defaults to "ec2-user"
         SSHPublicKey: publicKey,
       })
       .promise();
 
     // Write audit event
     await this.audit(requestContext, {
-      action: "env-send-ssh-public-key",
+      action: 'env-send-ssh-public-key',
       body: { id: envId, connection },
     });
 
@@ -422,11 +362,10 @@ class EnvironmentScConnectionService extends Service {
   }
 
   async getWindowsPasswordDataForRdp(requestContext, envId, connectionId) {
-    const [environmentScService, environmentScKeypairService] =
-      await this.service([
-        "environmentScService",
-        "environmentScKeypairService",
-      ]);
+    const [environmentScService, environmentScKeypairService] = await this.service([
+      'environmentScService',
+      'environmentScKeypairService',
+    ]);
 
     // Verify environment is linked to an AppStream project when application has AppStream enabled
     const { projectId } = await environmentScService.mustFind(requestContext, {
@@ -436,59 +375,45 @@ class EnvironmentScConnectionService extends Service {
 
     // The following will succeed only if the user has permissions to access the specified environment
     // and connection
-    const connection = await this.mustFindConnection(
-      requestContext,
-      envId,
-      connectionId
-    );
+    const connection = await this.mustFindConnection(requestContext, envId, connectionId);
 
-    if (
-      connection.scheme !== connectionScheme.rdp &&
-      connection.scheme !== connectionScheme.customrdp
-    ) {
+    if (connection.scheme !== connectionScheme.rdp && connection.scheme !== connectionScheme.customrdp) {
       throw this.boom.badRequest(
         `The connection "${connectionId}" does not support RDP. Cannot retrieve windows password. The retrieval of windows password is only supported for RDP connections. Please contact your administrator.`,
-        true
+        true,
       );
     }
     if (_.isEmpty(connection.instanceId)) {
       throw this.boom.badRequest(
         `Could not determine the EC2 instance to RDP to for the connection "${connectionId}". This is most likely due to incorrect AWS CloudFormation output. Please contact your administrator.`,
-        true
+        true,
       );
     }
 
     const ec2 = await environmentScService.getClientSdkWithEnvMgmtRole(
       requestContext,
       { id: envId },
-      { clientName: "EC2", options: { apiVersion: "2016-11-15" } }
+      { clientName: 'EC2', options: { apiVersion: '2016-11-15' } },
     );
 
-    const data = await ec2
-      .describeInstances({ InstanceIds: [connection.instanceId] })
-      .promise();
-    const instanceInfo = _.get(data, "Reservations[0].Instances[0]");
+    const data = await ec2.describeInstances({ InstanceIds: [connection.instanceId] }).promise();
+    const instanceInfo = _.get(data, 'Reservations[0].Instances[0]');
 
     let password;
     if (connection.scheme === connectionScheme.rdp) {
-      const { PasswordData: passwordData } = await ec2
-        .getPasswordData({ InstanceId: connection.instanceId })
-        .promise();
-      const { privateKey } = await environmentScKeypairService.mustFind(
-        requestContext,
-        envId
-      );
+      const { PasswordData: passwordData } = await ec2.getPasswordData({ InstanceId: connection.instanceId }).promise();
+      const { privateKey } = await environmentScKeypairService.mustFind(requestContext, envId);
 
       password = crypto
         .privateDecrypt(
           { key: privateKey, padding: crypto.constants.RSA_PKCS1_PADDING },
-          Buffer.from(passwordData, "base64")
+          Buffer.from(passwordData, 'base64'),
         )
-        .toString("utf8");
+        .toString('utf8');
 
       // Write audit event
       await this.audit(requestContext, {
-        action: "env-windows-password-requested",
+        action: 'env-windows-password-requested',
         body: { id: envId, connection },
       });
     } else if (connection.scheme === connectionScheme.customrdp) {
@@ -500,88 +425,53 @@ class EnvironmentScConnectionService extends Service {
     };
   }
 
-  async createPrivateSageMakerUrl(
-    requestContext,
-    envId,
-    connection,
-    presign_retries = 10
-  ) {
-    const lockService = await this.service("lockService");
-    let signedURL = "";
+  async createPrivateSageMakerUrl(requestContext, envId, connection, presign_retries = 10) {
+    const lockService = await this.service('lockService');
+    let signedURL = '';
     try {
-      signedURL = await lockService.tryWriteLockAndRun(
-        { id: `${envId}presign` },
-        async () => {
-          if (!(_.toLower(_.get(connection, "type", "")) === "sagemaker")) {
-            throw this.boom.badRequest(
-              `Cannot generate presigned URL for non-sagemaker connection ${connection.type}`,
-              true
-            );
-          }
-          const environmentScService = await this.service(
-            "environmentScService"
+      signedURL = await lockService.tryWriteLockAndRun({ id: `${envId}presign` }, async () => {
+        if (!(_.toLower(_.get(connection, 'type', '')) === 'sagemaker')) {
+          throw this.boom.badRequest(
+            `Cannot generate presigned URL for non-sagemaker connection ${connection.type}`,
+            true,
           );
-          const iam = await environmentScService.getClientSdkWithEnvMgmtRole(
+        }
+        const environmentScService = await this.service('environmentScService');
+        const iam = await environmentScService.getClientSdkWithEnvMgmtRole(
+          requestContext,
+          { id: envId },
+          { clientName: 'IAM', options: { apiVersion: '2017-07-24' } },
+        );
+        const currentPolicyResponse = await this.getCurrentRolePolicy(iam, connection);
+        await this.updateRoleToIncludeCurrentIP(iam, connection, currentPolicyResponse);
+        const createPresignedURLFn = async () => {
+          const stsEnvMgmt = await environmentScService.getClientSdkWithEnvMgmtRole(
             requestContext,
             { id: envId },
-            { clientName: "IAM", options: { apiVersion: "2017-07-24" } }
+            { clientName: 'STS', options: { apiVersion: '2017-07-24' } },
           );
-          const currentPolicyResponse = await this.getCurrentRolePolicy(
-            iam,
-            connection
-          );
-          await this.updateRoleToIncludeCurrentIP(
-            iam,
-            connection,
-            currentPolicyResponse
-          );
-          const createPresignedURLFn = async () => {
-            const stsEnvMgmt =
-              await environmentScService.getClientSdkWithEnvMgmtRole(
-                requestContext,
-                { id: envId },
-                { clientName: "STS", options: { apiVersion: "2017-07-24" } }
-              );
-            const sageMakerResponse = await this.createPresignedURL(
-              stsEnvMgmt,
-              connection
-            );
-            return sageMakerResponse;
-          };
-          try {
-            // Give sufficient number of retries to create presigned URL.
-            // This is needed because IAM role takes a while to propagate
-            // call with a linear strategy where we wait 2 seconds between retries
-            // This makes it 20 seconds with default of 10 retries
-            const sageMakerResponse = await retry(
-              createPresignedURLFn,
-              presign_retries,
-              () => linearInterval(1, 2000)
-            );
-            return _.get(sageMakerResponse, "AuthorizedUrl");
-          } catch (error) {
-            throw this.boom
-              .internalError(`Could not generate presigned URL`, true)
-              .cause(error);
-          } finally {
-            // restore the original policy document. This ensures that caller IP address which was responsible for
-            // creating the presigned URL doesn't have access
-            const oldPolicyDocument = decodeURIComponent(
-              currentPolicyResponse.PolicyDocument
-            );
-            await this.putRolePolicy(iam, connection, oldPolicyDocument);
-          }
+          const sageMakerResponse = await this.createPresignedURL(stsEnvMgmt, connection);
+          return sageMakerResponse;
+        };
+        try {
+          // Give sufficient number of retries to create presigned URL.
+          // This is needed because IAM role takes a while to propagate
+          // call with a linear strategy where we wait 2 seconds between retries
+          // This makes it 20 seconds with default of 10 retries
+          const sageMakerResponse = await retry(createPresignedURLFn, presign_retries, () => linearInterval(1, 2000));
+          return _.get(sageMakerResponse, 'AuthorizedUrl');
+        } catch (error) {
+          throw this.boom.internalError(`Could not generate presigned URL`, true).cause(error);
+        } finally {
+          // restore the original policy document. This ensures that caller IP address which was responsible for
+          // creating the presigned URL doesn't have access
+          const oldPolicyDocument = decodeURIComponent(currentPolicyResponse.PolicyDocument);
+          await this.putRolePolicy(iam, connection, oldPolicyDocument);
         }
-      );
+      });
     } catch (e) {
-      if (
-        this.boom.is(e, "internalError") &&
-        e.message === "Could not obtain a lock"
-      ) {
-        throw this.boom.tooManyRequests(
-          "Please wait 30 seconds before requesting Sagemaker URL",
-          true
-        );
+      if (this.boom.is(e, 'internalError') && e.message === 'Could not obtain a lock') {
+        throw this.boom.tooManyRequests('Please wait 30 seconds before requesting Sagemaker URL', true);
       }
       throw e;
     }
@@ -600,24 +490,20 @@ class EnvironmentScConnectionService extends Service {
 
   async updateRoleToIncludeCurrentIP(iam, connection, currentPolicyResponse) {
     // Construct new statement which will allow the caller IP address permission to generate the presigned URL
-    const currentIpAddress = await fetch("http://checkip.amazonaws.com/").then(
-      function (res) {
-        return res.text();
-      }
-    );
+    const currentIpAddress = await fetch('http://checkip.amazonaws.com/').then(function(res) {
+      return res.text();
+    });
     const newStatement = {
-      Effect: "Allow",
-      Action: "sagemaker:CreatePresignedNotebookInstanceUrl",
+      Effect: 'Allow',
+      Action: 'sagemaker:CreatePresignedNotebookInstanceUrl',
       Resource: `${connection.notebookArn}`,
       Condition: {
         IpAddress: {
-          "aws:SourceIp": `${currentIpAddress.trim()}/32`,
+          'aws:SourceIp': `${currentIpAddress.trim()}/32`,
         },
       },
     };
-    const policyToUpdate = JSON.parse(
-      decodeURIComponent(currentPolicyResponse.PolicyDocument)
-    );
+    const policyToUpdate = JSON.parse(decodeURIComponent(currentPolicyResponse.PolicyDocument));
     let policyToUpdateStatement = policyToUpdate.Statement;
     if (_.isArray(policyToUpdateStatement)) {
       policyToUpdateStatement.push(newStatement);
@@ -639,11 +525,7 @@ class EnvironmentScConnectionService extends Service {
 
   async createPresignedURL(stsEnvMgmt, connection) {
     const {
-      Credentials: {
-        AccessKeyId: accessKeyId,
-        SecretAccessKey: secretAccessKey,
-        SessionToken: sessionToken,
-      },
+      Credentials: { AccessKeyId: accessKeyId, SecretAccessKey: secretAccessKey, SessionToken: sessionToken },
     } = await stsEnvMgmt
       .assumeRole({
         RoleArn: connection.roleArn,
@@ -659,20 +541,18 @@ class EnvironmentScConnectionService extends Service {
     const params = {
       NotebookInstanceName: connection.info,
     };
-    const sageMakerResponse = await sagemaker
-      .createPresignedNotebookInstanceUrl(params)
-      .promise();
+    const sageMakerResponse = await sagemaker.createPresignedNotebookInstanceUrl(params).promise();
     return sageMakerResponse;
   }
 
   // Getter for AWS method to make mocking easier in unit tests
   async getAWS() {
-    const aws = await this.service("aws");
+    const aws = await this.service('aws');
     return aws;
   }
 
   async audit(requestContext, auditEvent) {
-    const auditWriterService = await this.service("auditWriterService");
+    const auditWriterService = await this.service('auditWriterService');
     // Calling "writeAndForget" instead of "write" to allow main call to continue without waiting for audit logging
     // and not fail main call if audit writing fails for some reason
     // If the main call also needs to fail in case writing to any audit destination fails then switch to "write" method as follows
@@ -685,13 +565,13 @@ class EnvironmentScConnectionService extends Service {
    * @param instanceInfo
    */
   toNetworkInterfaces(instanceInfo) {
-    const networkInterfaces = _.get(instanceInfo, "NetworkInterfaces") || [];
-    const networkInterfacesTransformed = _.map(networkInterfaces, (ni) => {
+    const networkInterfaces = _.get(instanceInfo, 'NetworkInterfaces') || [];
+    const networkInterfacesTransformed = _.map(networkInterfaces, ni => {
       return {
-        publicDnsName: _.get(ni, "Association.PublicDnsName"),
-        publicIp: _.get(ni, "Association.PublicIp"),
-        privateDnsName: _.get(ni, "PrivateDnsName"),
-        privateIp: _.get(ni, "PrivateIpAddress"),
+        publicDnsName: _.get(ni, 'Association.PublicDnsName'),
+        publicIp: _.get(ni, 'Association.PublicIp'),
+        privateDnsName: _.get(ni, 'PrivateDnsName'),
+        privateIp: _.get(ni, 'PrivateIpAddress'),
       };
     });
     return networkInterfacesTransformed;


### PR DESCRIPTION
This repo contains files that override the original SWB files. Some of these files were formatted using different settings to that of the SWB file, leading to a larger than necessary diff. This makes it difficult to see the changes, or to update to future SWB versions.

This PR attempts to reformat these files to minimise the diff against SWB v5.2.7. There should be no logical changes.

From a checkout of https://github.com/awslabs/service-workbench-on-aws/tree/v5.2.7:

- `rsync -av ../treehoose-swb-customisations/src/ ./`
- `pnpm install; pnpm run format --recursive --if-present --no-bail`
- Fix formatting of `onboard-account.cfn.yml`
- Manual fixes to minimise diff
- Copy files back to treehoose-swb-customisations

Diff after applying these changes to SWB 5.2.7:

<details>

```
rsync -av ../treehoose-swb-customisations/src/ ./
git diff
```
```diff
diff --git a/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/appstream/appstream-sc-service.js b/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/appstream/appstream-sc-service.js
index 5e0f79c7..ab6d65c7 100644
--- a/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/appstream/appstream-sc-service.js
+++ b/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/appstream/appstream-sc-service.js
@@ -12,10 +12,12 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-
+const crypto = require('crypto');
 const _ = require('lodash');
 const Service = require('@amzn/base-services-container/lib/service');
 
+const ENABLE_PASSWORD_SHARE = false;
+
 const settingKeys = {
   enableAmiSharing: 'enableAmiSharing',
   devopsRoleArn: 'devopsRoleArn',
@@ -113,7 +115,7 @@ class AppStreamScService extends Service {
     return `${uid}-${sessionSuffix}`.replace(/[^\w+=,.@-]+/g, '').slice(0, 32);
   }
 
-  async getStreamingUrl(requestContext, { environmentId, applicationId }) {
+  async getStreamingUrl(requestContext, { environmentId, applicationId, sessionContext }) {
     const environmentScService = await this.service('environmentScService');
 
     const appStream = await environmentScService.getClientSdkWithEnvMgmtRole(
@@ -138,6 +140,7 @@ class AppStreamScService extends Service {
           StackName: stackName,
           UserId: this.generateUserId(requestContext, environment),
           ApplicationId: applicationId,
+          SessionContext: sessionContext,
         })
         .promise();
     } catch (err) {
@@ -151,9 +154,15 @@ class AppStreamScService extends Service {
   }
 
   async urlForRemoteDesktop(requestContext, { environmentId, instanceId }) {
-    const environmentScService = await this.service('environmentScService');
+    const [environmentScService, environmentScKeypairService] = await this.service([
+      'environmentScService',
+      'environmentScKeypairService',
+    ]);
     const environment = await environmentScService.mustFind(requestContext, { id: environmentId });
 
+    const connectionScheme = environment.outputs.filter(output =>
+      output.OutputValue === 'customrdp' || output.OutputValue === 'rdp' ? output.OutputValue : undefined,
+    );
     // Get stack and fleet
     const { stackName, fleetName } = await this.getStackAndFleet(requestContext, {
       environmentId,
@@ -179,6 +188,33 @@ class AppStreamScService extends Service {
     const userId = this.generateUserId(requestContext, environment);
     this.log.info({ msg: `Creating AppStream URL`, appStreamSessionUid: userId });
 
+    let sessionContext;
+    if (connectionScheme && connectionScheme[0].OutputValue === 'rdp') {
+      sessionContext = `${privateIp},Administrator,rdp`;
+      if (ENABLE_PASSWORD_SHARE) {
+        const { PasswordData: passwordData } = await ec2.getPasswordData({ InstanceId: instanceId }).promise();
+        const { privateKey } = await environmentScKeypairService.mustFind(requestContext, environmentId);
+
+        const password = crypto
+          .privateDecrypt(
+            { key: privateKey, padding: crypto.constants.RSA_PKCS1_PADDING },
+            Buffer.from(passwordData, 'base64'),
+          )
+          .toString('utf8');
+
+        // Write audit event
+        await this.audit(requestContext, {
+          action: 'env-windows-password-requested',
+          body: { id: environmentId, instanceId },
+        });
+        sessionContext = `${sessionContext},${password}`;
+      }
+    } else if (connectionScheme && connectionScheme[0].OutputValue === 'customrdp') {
+      sessionContext = `${privateIp},ec2-user,customrdp`;
+      sessionContext = ENABLE_PASSWORD_SHARE ? `${sessionContext},${instanceId}` : sessionContext;
+    } else {
+      sessionContext = privateIp;
+    }
     let result = {};
     try {
       result = await appStream
@@ -186,8 +222,8 @@ class AppStreamScService extends Service {
           FleetName: fleetName,
           StackName: stackName,
           UserId: userId,
-          ApplicationId: 'MicrosoftRemoteDesktop',
-          SessionContext: privateIp,
+          ApplicationId: 'remmina-client',
+          SessionContext: sessionContext,
         })
         .promise();
     } catch (err) {
diff --git a/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/env-sc-connection-url-plugin.js b/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/env-sc-connection-url-plugin.js
index 398d4532..7b2ae74f 100644
--- a/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/env-sc-connection-url-plugin.js
+++ b/addons/addon-base-raas-appstream/packages/base-raas-appstream-services/lib/plugins/env-sc-connection-url-plugin.js
@@ -24,9 +24,10 @@ async function createConnectionUrl({ envId, connection }, { requestContext, cont
   // Only wraps web urls via app stream (i.e., scheme = 'http' or 'https' or no scheme)
   const isHttp = connection.scheme === 'http' || connection.scheme === 'https' || _.isEmpty(connection.scheme);
   const isSsh = connection.scheme === 'ssh';
-  const isRdp = connection.scheme === 'rdp';
+  const isRdp = connection.scheme === 'rdp' || connection.scheme === 'customrdp';
   const appStreamScService = await container.find('appStreamScService');
   const environmentScConnectionService = await container.find('environmentScConnectionService');
+  const environmentScService = await container.find('environmentScService');
   const settings = await container.find('settings');
   const isAppStreamEnabled = settings.getBoolean(settingKeys.isAppStreamEnabled);
 
@@ -50,16 +51,26 @@ async function createConnectionUrl({ envId, connection }, { requestContext, cont
     });
     appStreamUrl = await appStreamScService.getStreamingUrl(requestContext, {
       environmentId: envId,
-      applicationId: 'Firefox',
+      applicationId: 'firefox',
     });
   } else if (isSsh) {
     log.debug({
       msg: `Target instance ${connection.instanceId} will be available for SSH connection via AppStream URL`,
       connection,
     });
+    const ec2 = await environmentScService.getClientSdkWithEnvMgmtRole(
+      requestContext,
+      { id: envId },
+      { clientName: 'EC2', options: { apiVersion: '2016-11-15' } },
+    );
+    const data = await ec2.describeInstances({ InstanceIds: [connection.instanceId] }).promise();
+    const instanceInfo = _.get(data, 'Reservations[0].Instances[0]');
+    const networkInterfaces = _.get(instanceInfo, 'NetworkInterfaces') || [];
+    const privateIp = _.get(networkInterfaces[0], 'PrivateIpAddress');
     appStreamUrl = await appStreamScService.getStreamingUrl(requestContext, {
       environmentId: envId,
-      applicationId: 'EC2Linux',
+      applicationId: 'terminal',
+      sessionContext: `${privateIp},ec2-user`,
     });
   } else if (isRdp) {
     log.debug({
diff --git a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/forms/AddUpdateAwsAccountForm.js b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/forms/AddUpdateAwsAccountForm.js
index ab294826..ef20859f 100644
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/forms/AddUpdateAwsAccountForm.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/models/forms/AddUpdateAwsAccountForm.js
@@ -43,7 +43,7 @@ const addUpdateAwsAccountAppStreamFormFields = {
     label: 'AppStream Fleet Desired Instance',
     placeholder:
       'Maximum number of concurrently running AppStream sessions. Each researcher uses one AppStream session when viewing a workspace',
-    rules: 'required|integer',
+    rules: 'required_unless:appStreamFleetType,ELASTIC|integer',
   },
   appStreamDisconnectTimeoutSeconds: {
     label: 'AppStreamDisconnectTimeoutSeconds',
@@ -64,7 +64,7 @@ const addUpdateAwsAccountAppStreamFormFields = {
   appStreamImageName: {
     label: 'AppStreamImageName',
     placeholder: 'The name of the image used to create the fleet',
-    rules: 'required|string',
+    rules: 'required_unless:appStreamFleetType,ELASTIC|string',
   },
   appStreamInstanceType: {
     label: 'AppStreamInstanceType',
@@ -74,8 +74,8 @@ const addUpdateAwsAccountAppStreamFormFields = {
   },
   appStreamFleetType: {
     label: 'AppStreamFleetType',
-    placeholder: 'The fleet type. Should be either ALWAYS_ON or ON_DEMAND',
-    rules: ['required', 'regex:/^ALWAYS_ON|ON_DEMAND$/'],
+    placeholder: 'The fleet type. Should be either ALWAYS_ON, ELASTIC or ON_DEMAND',
+    rules: ['required', 'regex:/^ALWAYS_ON|ON_DEMAND|ELASTIC$/'],
   },
 };
 
diff --git a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentConnections.js b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentConnections.js
index 06db32a2..cc0fc720 100644
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentConnections.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentConnections.js
@@ -85,16 +85,19 @@ class ScEnvironmentConnections extends React.Component {
     const isHttp = scheme => scheme === 'http' || scheme === 'https' || _.isEmpty(scheme);
     const isSsh = scheme => scheme === 'ssh';
     const isRdp = scheme => scheme === 'rdp';
+    const isCustomRdp = scheme => scheme === 'customrdp';
+
     const hasHttp = !_.isEmpty(env.getConnections(item => isHttp(item.scheme)));
     const hasSsh = !_.isEmpty(env.getConnections(item => isSsh(item.scheme)));
     const hasRdp = !_.isEmpty(env.getConnections(item => isRdp(item.scheme)));
+    const hasCustomRdp = !_.isEmpty(env.getConnections(item => isCustomRdp(item.scheme)));
 
     return (
       // Keep the order the way it is, otherwise the drop down menus in the ssh connections
       // will be cropped due to the 'fadeIn animated' changing the z index
       <>
         {hasHttp && <ScEnvironmentHttpConnections scEnvironment={env} />}
-        {hasRdp && <ScEnvironmentRdpConnections scEnvironment={env} />}
+        {(hasRdp || hasCustomRdp) && <ScEnvironmentRdpConnections scEnvironment={env} />}
         {hasSsh && <ScEnvironmentSshConnections scEnvironment={env} />}
       </>
     );
diff --git a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentHttpConnections.js b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentHttpConnections.js
index 189f7d8c..7977113a 100644
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentHttpConnections.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentHttpConnections.js
@@ -222,9 +222,9 @@ class ScEnvironmentHttpConnections extends React.Component {
               <Table.Row key={`${item.id}_destination`} className="fadeIn animated">
                 <Table.Cell colSpan="3" className="p3">
                   Click here to copy the destination URL:
-                  <CopyToClipboard text={destinationUrl} />
+                  <CopyToClipboard text={destinationUrl.replace('.sagemaker.aws', '.sagemaker.aws/lab')} />
                   <span data-testid="destination-url" style={destinationUrlStyle}>
-                    {destinationUrl}
+                    {destinationUrl.replace('.sagemaker.aws', '.sagemaker.aws/lab')}
                   </span>
                   <Button
                     floated="right"
diff --git a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentRdpConnectionRow.js b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentRdpConnectionRow.js
index 194762bb..48bf666b 100644
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentRdpConnectionRow.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentRdpConnectionRow.js
@@ -173,6 +173,7 @@ class ScEnvironmentRdpConnectionRow extends React.Component {
     const item = this.connection;
     const windowsRdpInfo = this.windowsRdpInfo;
     const interfaces = this.networkInterfaces;
+    const network = interfaces[0];
     const username = 'Administrator';
     const password = windowsRdpInfo.password;
     const showPassword = this.showPassword;
@@ -183,10 +184,7 @@ class ScEnvironmentRdpConnectionRow extends React.Component {
       <>
         <Table.Row key={`${item.id}__2`}>
           <Table.Cell className="p3">
-            <b>
-              Your Windows workspace can be accessed via an RDP client by using the DNS host name and credentials
-              defined below.
-            </b>
+            <b>Your workspace can be accessed via an RDP client by using the credentials defined below.</b>
             <List bulleted>
               {!this.isAppStreamEnabled && (
                 <List.Item>
@@ -202,7 +200,15 @@ class ScEnvironmentRdpConnectionRow extends React.Component {
                   </List>
                 </List.Item>
               )}
-
+              <List.Item>
+                The Private IP Address to be used:{' '}
+                <List bulleted>
+                  <List.Item key={network.value} className="flex">
+                    {this.renderHostLabel(network)}
+                    <CopyToClipboard text={network.value} />
+                  </List.Item>
+                </List>
+              </List.Item>
               <List.Item>
                 The username and password:
                 <List>
@@ -224,12 +230,8 @@ class ScEnvironmentRdpConnectionRow extends React.Component {
               Additional information about connecting via RDP can be found in the documentation below:
             </div>
             <List bulleted>
-              <List.Item
-                href="https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/connecting_to_windows_instance.html#connect-rdp"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Connect to Your Windows Instance
+              <List.Item href="https://remmina.org/remmina-rdp/" target="_blank" rel="noopener noreferrer">
+                Connect to workspace
               </List.Item>
             </List>
             {this.isAppStreamEnabled && (
diff --git a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentRdpConnections.js b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentRdpConnections.js
index b0414b13..0611fe8a 100644
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentRdpConnections.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentRdpConnections.js
@@ -14,10 +14,10 @@ class ScEnvironmentRdpConnections extends React.Component {
     return this.props.scEnvironment;
   }
 
-  // Returns only the connections that scheme = 'rdp'
+  // Returns only the connections that has rdp or customrdp scheme
   // [ {id, name: <string>(optional), instanceId: <string>, scheme: 'rdp'}, ... ]
   get connections() {
-    const connections = this.environment.getConnections(item => item.scheme === 'rdp');
+    const connections = this.environment.getConnections(item => item.scheme === 'rdp' || item.scheme === 'customrdp');
 
     return connections;
   }
@@ -51,9 +51,9 @@ class ScEnvironmentRdpConnections extends React.Component {
           <b>Connection instructions for your AppStream workspace:</b>
           <List bulleted>
             <List.Item>Click the &quot;Get Password&quot; button to retrieve user credentials for RDP</List.Item>
-            <List.Item>Copy credential information and Hit &quot;Connect&quot;</List.Item>
+            <List.Item>Hit &quot;Connect&quot;</List.Item>
             <List.Item>
-              A new AppStream session window will open with RDP login page. Paste the copied credentials
+              A new AppStream session window will open with RDP login page. If required copy and paste the credentials
             </List.Item>
           </List>
         </Segment>
diff --git a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentSshConnections.js b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentSshConnections.js
index 4f95eb84..d9f1eee3 100644
--- a/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentSshConnections.js
+++ b/addons/addon-base-raas-ui/packages/base-raas-ui/src/parts/environments-sc/parts/ScEnvironmentSshConnections.js
@@ -105,42 +105,22 @@ class ScEnvironmentSshConnections extends React.Component {
             Copy your private SSH key to AppStream
             <List bulleted>
               <List.Item>You must have downloaded the selected SSH key during creating it</List.Item>
-              <List.Item>Paste your SSH key&apos;s contents into Notepad in AppStream</List.Item>
-              <List.Item>
-                Save the file in the Downloads folder named like &quot;<i>KeyName</i>.pem&quot; (with quotes)
-              </List.Item>
+              <List.Item>Paste your SSH key&apos;s contents into the terminal window launched in AppStream</List.Item>
             </List>
           </List.Item>
+          <List.Item>You should be automatically logged into an SSH session.</List.Item>
           <List.Item>
-            Convert your private key to PPK format.
-            <List bulleted>
-              <List.Item>
-                PuttyGen will already be open in AppStream window. Click &quot;Load&quot; and select your PEM file
-              </List.Item>
-              <List.Item>
-                Click on &quot;Save private key&quot;. Click &quot;Yes&quot; to save without passphrase{' '}
-              </List.Item>
-            </List>
-          </List.Item>
-          <List.Item>
-            Use PPK file in Putty
-            <List bulleted>
-              <List.Item>Enter the private IP address in Putty and select SSH connection type</List.Item>
-              <List.Item>In the Category pane, expand Connection, expand SSH, and then choose Auth</List.Item>
-              <List.Item>Browse and select your PPK file for authentication. Click Open</List.Item>
-              <List.Item>When prompted to enter username, enter &quot;ec2-user&quot;</List.Item>
-            </List>
+            If you get a Permissions Denied error, click &quot;Use this SSH key&quot; and try launcing terminal
           </List.Item>
-          <List.Item>Delete your PEM and PPK files once EC2 connection is established</List.Item>
         </List>
-        <div className="mt3">More information on connecting to your Linux instance from Windows OS:</div>
+        <div className="mt3">More information on connecting to your Linux instance from terminal command line:</div>
         <List bulleted>
           <List.Item
-            href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/putty.html"
+            href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstancesLinux.html"
             target="_blank"
             rel="noopener noreferrer"
           >
-            Connecting from Windows via Putty
+            Connecting from Linux via command line
           </List.Item>
         </List>
         <div className="mt3">
diff --git a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
index f3d096b9..1ebf45db 100644
--- a/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
+++ b/addons/addon-base-raas/packages/base-raas-cfn-templates/src/templates/onboard-account.cfn.yml
@@ -99,25 +99,34 @@ Parameters:
   AppStreamFleetType:
     Description: The fleet type
     Type: String
-    AllowedValues: [ALWAYS_ON, ON_DEMAND]
+    AllowedValues: [ALWAYS_ON, ON_DEMAND, ELASTIC]
     Default: ON_DEMAND
 
+  AppStreamMaxConcurrentSessions:
+    Description: An upper limit on concurrent AppStream sessions for this researcher stack.
+    Type: Number
+    Default: 10
+
   DomainName:
     Description: Optional custom Domain name to be created in Route53
     Type: String
     Default: ''
-  
+
   EnableAmiSharing:
     Type: String
     AllowedValues: [true, false]
     Description: Use appstream image from the central devops account
     Default: false
-  
+
   DevopsAccountId:
     Type: String
     Description: The account id of the central AWS account where the appstream image is created.
     Default: ''
 
+  S3PrefixList:
+    Description: Specific to each region, subnet prefix list to S3. ("aws ec2 describe-prefix-lists --region=<REGION> --filter Name=prefix-list-name,Values=com.amazonaws.\*.s3")
+    Type: String
+    Default: pl-7ca54015 # for eu-west-2
   # Note: While adding additional CIDRs/Subnets ensure they don't overlap with those used by RStudio ALB (10.0.96.0 to 10.0.97.255)
 
 Metadata:
@@ -137,6 +146,17 @@ Metadata:
         Parameters:
           - VpcCidr
           - PublicSubnetCidr
+      - Label:
+          default: AppStream Configuration
+        Parameters:
+          - AppStreamImageName
+          - AppStreamFleetDesiredInstances
+          - AppStreamMaxConcurrentSessions
+          - AppStreamDisconnectTimeoutSeconds
+          - AppStreamIdleDisconnectTimeoutSeconds
+          - AppStreamMaxUserDurationSeconds
+          - AppStreamInstanceType
+          - AppStreamFleetType
 
 # Resources linked to AppStream conditions are evaluated further prior to getting sent to CloudFormation
 # Take a look at addons/addon-base-raas/packages/base-raas-services/lib/cfn-templates/cfn-template-service.getTemplate()
@@ -145,16 +165,28 @@ Conditions:
     - !Ref EnableAppStream
     - true
   isNotAppStream: !Not [Condition: isAppStream]
-  hasCustomDomain: !Not [!Equals [!Ref 'DomainName', '']]
+  isElasticAppStream:
+    !And [
+      !Equals [!Ref 'EnableAppStream', true],
+      !Equals [!Ref 'AppStreamFleetType', ELASTIC],
+    ]
+  isNotElasticAppStream: !Not [Condition: isElasticAppStream]
   isAppStreamAndCustomDomain: !And
     - !Not [!Equals [!Ref 'DomainName', '']]
     - !Condition isAppStream
   enableFlowLogs: !Equals [!Ref EnableFlowLogs, true]
   enableFlowLogsNonAppStream: !And [Condition: isNotAppStream,Condition: enableFlowLogs]
   enableFlowLogsWithAppStream: !And [Condition: isAppStream,Condition: enableFlowLogs]
-  amiSharingEnabled: !Equals
-    - !Ref EnableAmiSharing
-    - true
+  amiSharingEnabled:
+    !And [
+      !Equals [!Ref 'EnableAmiSharing', true],
+      Condition: isNotElasticAppStream,
+    ]
+  notAmiSharingEnabled:
+    !And [
+      !Not [!Equals [!Ref 'EnableAmiSharing', true]],
+      Condition: isNotElasticAppStream,
+    ]
 
 Resources:
   Route53HostedZone:
@@ -768,10 +800,11 @@ Resources:
     Properties:
       AliasName: !Join ['', ['alias/', Ref: Namespace, '-encryption-key']]
       TargetKeyId: !Ref EncryptionKey
-  
+
   FlowLogCloudwatchGroup:
     Type: 'AWS::Logs::LogGroup'
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       LogGroupName: !Join ['', [Ref: Namespace, '-flow-logger']]
       RetentionInDays: 30
@@ -878,6 +911,11 @@ Resources:
               - '*'
       RouteTableIds:
         - !Ref PrivateWorkspaceRouteTable
+        - !If [
+            isElasticAppStream,
+            !Ref AppStreamSubnetRouteTable,
+            !Ref 'AWS::NoValue',
+          ]
       VpcEndpointType: Gateway
       ServiceName: !Sub 'com.amazonaws.${AWS::Region}.s3'
       VpcId: !Ref VPC
@@ -1051,6 +1089,11 @@ Resources:
           IpProtocol: '-1'
         - DestinationSecurityGroupId: !Ref WorkspaceSecurityGroup
           IpProtocol: '-1'
+        - !If
+          - isElasticAppStream
+          - DestinationPrefixListId: !Ref S3PrefixList
+            IpProtocol: '-1'
+          - !Ref 'AWS::NoValue'
 
   AppStreamSecurityGroupEgress:
     Type: AWS::EC2::SecurityGroupEgress
@@ -1070,28 +1113,101 @@ Resources:
       Description: 'Allow AppStream ingress from interface endpoint of SageMaker'
       IpProtocol: '-1'
 
+  AppStreamSubnet2:
+    Type: AWS::EC2::Subnet
+    Condition: isElasticAppStream
+    Properties:
+      VpcId: !Ref VPC
+      AvailabilityZone: !Select [1, !GetAZs '']
+      CidrBlock: !Select [3, !Cidr [!Ref VpcCidr, 4, 13]]
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub ${Namespace} Private AppStream Subnet
+
+  AppStreamSubnetRouteTable:
+    Type: AWS::EC2::RouteTable
+    Condition: isElasticAppStream
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub ${Namespace} appstream subnet routes
+
+  AppStreamSubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Condition: isElasticAppStream
+    Properties:
+      RouteTableId: !Ref AppStreamSubnetRouteTable
+      SubnetId: !Ref PrivateAppStreamSubnet
+
+  AppStreamSubnet2RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Condition: isElasticAppStream
+    Properties:
+      RouteTableId: !Ref AppStreamSubnetRouteTable
+      SubnetId: !Ref AppStreamSubnet2
+
+  AppStreamInstanceRole:
+    Type: 'AWS::IAM::Role'
+    Condition: isElasticAppStream
+    Properties:
+      RoleName: !Join ['-', [Ref: Namespace, 'appstream-instance']]
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: 'Allow'
+            Principal:
+              Service: 'appstream.amazonaws.com'
+            Action:
+              - 'sts:AssumeRole'
+
   AppStreamFleet:
     Type: 'AWS::AppStream::Fleet'
     Condition: isAppStream
     Properties:
-      ComputeCapacity:
-        DesiredInstances: !Ref AppStreamFleetDesiredInstances
+      ComputeCapacity: !If
+        - isNotElasticAppStream
+        - DesiredInstances: !Ref AppStreamFleetDesiredInstances
+        - !Ref 'AWS::NoValue'
       Description: 'SWB AppStream Fleet'
       DisconnectTimeoutInSeconds: !Ref AppStreamDisconnectTimeoutSeconds
       DisplayName: 'SWB Fleet'
       EnableDefaultInternetAccess: False
       FleetType: !Ref AppStreamFleetType
       IdleDisconnectTimeoutInSeconds: !Ref AppStreamIdleDisconnectTimeoutSeconds
-      ImageArn: !If [amiSharingEnabled, !Sub 'arn:aws:appstream:${AWS::Region}:${DevopsAccountId}:image/${AppStreamImageName}', !Sub 'arn:aws:appstream:${AWS::Region}:${CentralAccountId}:image/${AppStreamImageName}']
+      ImageArn: !If
+        - amiSharingEnabled
+        - !Sub 'arn:aws:appstream:${AWS::Region}:${DevopsAccountId}:image/${AppStreamImageName}'
+        - !If
+          - notAmiSharingEnabled
+          - !Sub 'arn:aws:appstream:${AWS::Region}:${CentralAccountId}:image/${AppStreamImageName}'
+          - !Ref 'AWS::NoValue'
       InstanceType: !Ref AppStreamInstanceType
       MaxUserDurationInSeconds: !Ref AppStreamMaxUserDurationSeconds
       Name: !Sub ${Namespace}-ServiceWorkbenchFleet
       StreamView: 'APP'
+      MaxConcurrentSessions:
+        !If [
+          isElasticAppStream,
+          !Ref AppStreamMaxConcurrentSessions,
+          !Ref 'AWS::NoValue',
+        ]
+      IamRoleArn:
+        !If [
+          isElasticAppStream,
+          !GetAtt AppStreamInstanceRole.Arn,
+          !Ref 'AWS::NoValue',
+        ]
+      Platform: !If [isElasticAppStream, 'AMAZON_LINUX2', !Ref 'AWS::NoValue']
       VpcConfig:
         SecurityGroupIds:
           - !Ref AppStreamSecurityGroup
         SubnetIds:
           - !Ref PrivateAppStreamSubnet
+          - !If [isElasticAppStream, !Ref AppStreamSubnet2, !Ref 'AWS::NoValue']
+    CreationPolicy:
+      StartFleet: True
 
   AppStreamStack:
     Type: 'AWS::AppStream::Stack'
@@ -1185,6 +1301,11 @@ Outputs:
     Condition: isAppStream
     Value: !Ref AppStreamStack
 
+  AppStreamInstanceRole:
+    Description: AppStream instance role name
+    Condition: isElasticAppStream
+    Value: !Ref AppStreamInstanceRole
+
   InterfaceEndpointSG:
     Description: Security group of Interface endpoints
     Condition: isAppStream
diff --git a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-connection-enum.js b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-connection-enum.js
index 8aa69fb3..c7a4a38d 100644
--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-connection-enum.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-connection-enum.js
@@ -20,6 +20,7 @@ const connectionScheme = {
   https: 'https',
   rdp: 'rdp',
   ssh: 'ssh',
+  customrdp: 'customrdp',
 };
 const supportedConnectionSchemes = _.values(connectionScheme);
 module.exports = { connectionScheme, supportedConnectionSchemes };
diff --git a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-connection-service.js b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-connection-service.js
index b82b5d07..09afb9df 100644
--- a/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-connection-service.js
+++ b/addons/addon-base-raas/packages/base-raas-services/lib/environment/service-catalog/environment-sc-connection-service.js
@@ -20,7 +20,7 @@ const NodeRSA = require('node-rsa');
 const querystring = require('querystring');
 const Service = require('@amzn/base-services-container/lib/service');
 const { retry, linearInterval } = require('@amzn/base-services/lib/helpers/utils');
-const sshConnectionInfoSchema = require('../../schema/ssh-connection-info-sc.json');
+const sshConnectionInfoSchema = require('../../schema/ssh-connection-info-sc');
 const { connectionScheme } = require('./environment-sc-connection-enum');
 const { cfnOutputsToConnections } = require('./helpers/connections-util');
 
@@ -191,8 +191,8 @@ class EnvironmentScConnectionService extends Service {
         NotebookInstanceName: connection.info,
       };
       const sageMakerResponse = await sagemaker.createPresignedNotebookInstanceUrl(params).promise();
-
-      connection.url = _.get(sageMakerResponse, 'AuthorizedUrl');
+      this.log.info();
+      connection.url = _.get(sageMakerResponse, 'AuthorizedUrl').replace('?', '/lab?');
     }
 
     if (
@@ -362,7 +362,7 @@ class EnvironmentScConnectionService extends Service {
     // and connection
     const connection = await this.mustFindConnection(requestContext, envId, connectionId);
 
-    if (connection.scheme !== connectionScheme.rdp) {
+    if (connection.scheme !== connectionScheme.rdp && connection.scheme !== connectionScheme.customrdp) {
       throw this.boom.badRequest(
         `The connection "${connectionId}" does not support RDP. Cannot retrieve windows password. The retrieval of windows password is only supported for RDP connections. Please contact your administrator.`,
         true,
@@ -381,23 +381,33 @@ class EnvironmentScConnectionService extends Service {
       { clientName: 'EC2', options: { apiVersion: '2016-11-15' } },
     );
 
-    const { PasswordData: passwordData } = await ec2.getPasswordData({ InstanceId: connection.instanceId }).promise();
-    const { privateKey } = await environmentScKeypairService.mustFind(requestContext, envId);
-
-    const password = crypto
-      .privateDecrypt(
-        { key: privateKey, padding: crypto.constants.RSA_PKCS1_PADDING },
-        Buffer.from(passwordData, 'base64'),
-      )
-      .toString('utf8');
-
-    // Write audit event
-    await this.audit(requestContext, { action: 'env-windows-password-requested', body: { id: envId, connection } });
-
     const data = await ec2.describeInstances({ InstanceIds: [connection.instanceId] }).promise();
     const instanceInfo = _.get(data, 'Reservations[0].Instances[0]');
 
-    return { password, networkInterfaces: this.toNetworkInterfaces(instanceInfo) };
+    let password;
+    if (connection.scheme === connectionScheme.rdp) {
+      const { PasswordData: passwordData } = await ec2.getPasswordData({ InstanceId: connection.instanceId }).promise();
+      const { privateKey } = await environmentScKeypairService.mustFind(requestContext, envId);
+
+      password = crypto
+        .privateDecrypt(
+          { key: privateKey, padding: crypto.constants.RSA_PKCS1_PADDING },
+          Buffer.from(passwordData, 'base64'),
+        )
+        .toString('utf8');
+
+      // Write audit event
+      await this.audit(requestContext, {
+        action: 'env-windows-password-requested',
+        body: { id: envId, connection },
+      });
+    } else if (connection.scheme === connectionScheme.customrdp) {
+      password = connection.instanceId;
+    }
+    return {
+      password,
+      networkInterfaces: this.toNetworkInterfaces(instanceInfo),
+    };
   }
 
   async createPrivateSageMakerUrl(requestContext, envId, connection, presign_retries = 10) {
@@ -508,7 +518,11 @@ class EnvironmentScConnectionService extends Service {
       })
       .promise();
     const aws = await this.getAWS();
-    const sagemaker = new aws.sdk.SageMaker({ accessKeyId, secretAccessKey, sessionToken });
+    const sagemaker = new aws.sdk.SageMaker({
+      accessKeyId,
+      secretAccessKey,
+      sessionToken,
+    });
     const params = {
       NotebookInstanceName: connection.info,
     };
diff --git a/main/solution/post-deployment/config/environment-files/bootstrap.sh b/main/solution/post-deployment/config/environment-files/bootstrap.sh
index 7de03009..789fe28b 100644
--- a/main/solution/post-deployment/config/environment-files/bootstrap.sh
+++ b/main/solution/post-deployment/config/environment-files/bootstrap.sh
@@ -29,6 +29,9 @@ env_type() {
     elif [ -d "/var/log/rstudio-server" ]
     then
         printf "rstudio"
+    elif [ -d "/home/ubuntu" ]
+    then
+        printf "ubuntu"
     else
         printf "ec2-linux"
     fi
@@ -133,6 +136,8 @@ case "$(env_type)" in
         chmod +x "/usr/local/bin/jq"
         echo "Finish installing jq"
         ;;
+    "ubuntu")
+        echo "Ubuntu workspace with JQ pre-installed"
 esac
 
 echo "Copying Goofys from bootstrap.sh"
@@ -200,6 +205,10 @@ case "$(env_type)" in
         echo "Finish installing fuse"
         printf "\n# Mount S3 study data\nmount_s3.sh\n\n" >> "/home/rstudio-user/.bash_profile"
         ;;
+    "ubuntu")
+        echo "Ubuntu workspace with FUSE preinstalled"
+        echo "Enabling mount of studies on user login"
+        printf "[Desktop Entry]\nType=Application\nName=Mount studies\nExec=/usr/local/bin/mount_s3.sh\nIcon=system-run\nX-GNOME-Autostart-enabled=true\n" >> "/etc/xdg/autostart/mount_s3.desktop"
 esac
 
-exit 0
\ No newline at end of file
+exit 0
```

</details>

---

Declaration : _By submitting this pull request, I confirm that my contribution
is made under the terms of the Apache-2.0 license_
